### PR TITLE
Revert back `eltype{T}(::Poly{T})`

### DIFF
--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -12,7 +12,7 @@ export degree, coeffs, variable
 export polyval, polyint, polyder, roots, polyfit
 export Pade, padeval
 
-import Base: start, next, done, length, size, eltype
+import Base: start, next, done, length, size, eltype, collect
 import Base: endof, getindex, setindex!, copy, zero, one, convert, norm, gcd
 import Base: show, print, *, /, //, -, +, ==, isapprox, divrem, div, rem, eltype
 import Base: promote_rule, truncate, chop,  conj, transpose, dot, hash
@@ -134,7 +134,8 @@ convert{T, S<:Number}(::Type{Poly{T}}, x::S, var::SymbolLike=:x) = Poly(T[x], va
 convert{T, S<:Number}(::Type{Poly{T}}, x::AbstractArray{S}, var::SymbolLike=:x) = map(el->Poly(T[el],var), x)
 promote_rule{T, S}(::Type{Poly{T}}, ::Type{Poly{S}}) = Poly{promote_type(T, S)}
 promote_rule{T, S<:Number}(::Type{Poly{T}}, ::Type{S}) = Poly{promote_type(T, S)}
-eltype{T}(::Poly{T}) = Poly{T}
+# Check JuliaLang/METADATA.jl#8528
+eltype{T}(::Poly{T}) = T
 
 length(p::Poly) = length(coeffs(p))
 endof(p::Poly)  = length(p) - 1
@@ -143,6 +144,9 @@ start(p::Poly)        = start(coeffs(p)) - 1
 next(p::Poly, state)  = (temp = zeros(coeffs(p)); temp[state+1] = p[state]; (Poly(temp), state+1))
 done(p::Poly, state)  = state > degree(p)
 eltype{T}(::Type{Poly{T}}) = Poly{T}
+
+# shortcut for collect(eltype, collection)
+collect{T}(p::Poly{T}) = collect(Poly{T}, p)
 
 size(p::Poly) = size(p.a)
 size(p::Poly, i::Integer) = size(p.a, i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -326,4 +326,16 @@ for term in p1
 end
 
 @test eltype(typeof(p1)) == typeof(p1)
+
+# after implementing the iteration interface, i.e., `start` and its friends,
+# previously throwing `collect` function (and maybe, other similar functions)
+# started giving different errors due to `eltype{T}(::Poly{T}) = T`. Changing
+# this definition has resulted in JuliaLang/METADATA.jl#8528. One small fix
+# was to direct `collect{T}(p::Poly{T})` to `collect(Poly{T}, p)`.
+
+@test eltype(p1) == Int
+@test eltype(collect(p1)) == Poly{Int}
+@test eltype(collect(Poly{Float64}, p1)) == Poly{Float64}
+@test_throws InexactError collect(Poly{Int}, Poly([1.2]))
+
 @test length(collect(p1)) == degree(p1)+1


### PR DESCRIPTION
### Summary

Reverted back to `eltype{T}(::Poly{T}) = T`.

### Reasoning
With this pair of `eltype{T}(::Type{Poly{T}})` and `eltype{T}(::Poly{T})`, the packages mentioned in JuliaLang/METADATA.jl#8528 all pass their tests in both `v0.4` and `v0.5`.

Any objections/suggestions regarding the change, @ararslan @jverzani and @neveritt?

If the change makes sense, should we also add a small test to prevent a future change in this `eltype`?