### PR TITLE
fix #120

### DIFF
--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -624,7 +624,7 @@ julia> roots(poly([1,2,3,4]))
 function roots{T}(p::Poly{T})
     R = promote_type(T, Float64)
     length(p) == 0 && return zeros(R, 0)
-    p = truncate(p)
+
     num_leading_zeros = 0
     while p[num_leading_zeros] ≈ zero(T)
         if num_leading_zeros == length(p)-1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,10 @@ a_roots = copy(pN.a)
 @test length(roots(p5)) == 4
 @test roots(pNULL) == []
 @test sort(roots(pR)) == [1//2, 3//2]
+x = variable(Float64)
+plarge = 8.362779449448982e41 - 2.510840694154672e57x + 4.2817430781178795e44x^2 - 1.6225927682921337e31x^3 + 1.0x^4  # #120
+@test length(roots(plarge)) == 4
+
 
 @test pNULL + 2 == p0 + 2 == 2 + p0 == Poly([2])
 @test p2 - 2 == -2 + p2 == Poly([-1,1])


### PR DESCRIPTION
This removes call to `truncate` in `roots`. Leaving `truncate` had unexpected results when the polynomial had very large coefficients. Users can still manually call truncate before calling `roots` if desired.