### PR TITLE
Extend and export printpoly

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.9.4
+Compat 0.9.5

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,6 +14,9 @@ The package can then be loaded into the current session using
 ```julia
 using Polynomials
 ```
+```@meta
+DocTestSetup = :( using Polynomials )
+```
 
 ## Functions
 
@@ -27,6 +30,7 @@ poly
 degree
 coeffs
 variable
+printpoly
 polyval
 polyint
 polyder

--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -8,7 +8,7 @@ module Polynomials
 using Compat
 
 export Poly, poly
-export degree, coeffs, variable
+export degree, coeffs, variable, printpoly
 export polyval, polyint, polyder, roots, polyfit
 export Pade, padeval
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -68,15 +68,32 @@ end
 
 ###
 
-function printpoly{T}(io::IO, p::Poly{T}, mimetype)
+"""
+    printpoly(io::IO, p::Poly, mimetype = MIME"text/plain"(); descending_powers=false)
+
+Print a human-readable representation of the polynomial `p` to `io`. The MIME
+types "text/plain" (default), "text/latex", and "text/html" are supported. By
+default, the terms are in order of ascending powers, matching the order in
+`coeffs(p)`; specifying `descending_powers=true` reverses the order.
+
+# Examples
+```jldoctest
+julia> printpoly(STDOUT, Poly([1,2,3], :y))
+1 + 2*y + 3*y^2
+julia> printpoly(STDOUT, Poly([1,2,3], :y), descending_powers=true)
+3*y^2 + 2*y + 1
+```
+"""
+function printpoly{T}(io::IO, p::Poly{T}, mimetype = MIME"text/plain"(); descending_powers=false)
     first = true
     printed_anything = false
-    for i in eachindex(p)
+    for i in (descending_powers ? reverse(eachindex(p)) : eachindex(p))
         printed = showterm(io,p,i,first, mimetype)
         first &= !printed
         printed_anything |= printed
     end
     printed_anything || print(io, zero(T))
+    return nothing
 end
 
 function showterm{T}(io::IO,p::Poly{T},j,first, mimetype)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -248,6 +248,14 @@ p = Poly([1,2,3])
 p = Poly([1//2, 2//3, 1])
 @test reprmime("text/latex", p) == "\$\\frac{1}{2} + \\frac{2}{3}\\cdot x + x^{2}\$"
 
+# customized printing with printpoly
+function printpoly_to_string(args...; kwargs...)
+    buf = IOBuffer()
+    printpoly(buf, args...; kwargs...)
+    return Compat.String(take!(buf))
+end
+@test printpoly_to_string(Poly([1,2,3], "y")) == "1 + 2*y + 3*y^2"
+@test printpoly_to_string(Poly([1,2,3], "y"), descending_powers=true) == "3*y^2 + 2*y + 1"
 
 ## want to be able to copy and paste
 if VERSION < v"0.6.0-dev"


### PR DESCRIPTION
Make `printpoly` part of the public API and add options to reverse the term order and to combine the powers with a power already present in the variable (if any).

Closes #77.