### PR TITLE
Julia v0.7 compatibility - lastindex/range

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -151,7 +151,12 @@ println("The approximate sum of the convergent series is: ",exp(1)*(-_γ-sum([(-
 
 
 ## polyfit
-xs = linspace(0, pi, 10)
+if VERSION < v"0.7-"
+    xs = linspace(0, pi, 10)
+else
+    xs = range(0, stop=pi, length=10)
+end
+
 ys = map(sin,xs)
 p = polyfit(xs, ys)
 p = polyfit(xs, ys, :t)
@@ -258,9 +263,16 @@ p = Poly([1.0, 0 + NaN*im, NaN, Inf, 0 - Inf*im]) # handle NaN or Inf appropriat
 @test repr(p) == "Poly(1.0 + NaN*im*x + NaN*x^2 + Inf*x^3 - Inf*im*x^4)"
 
 p = Poly([1,2,3])
-@test reprmime("text/latex", p) == "\$1 + 2\\cdot x + 3\\cdot x^{2}\$"
-p = Poly([1//2, 2//3, 1])
-@test reprmime("text/latex", p) == "\$\\frac{1}{2} + \\frac{2}{3}\\cdot x + x^{2}\$"
+
+if VERSION < v"0.7-"
+    @test reprmime("text/latex", p) == "\$1 + 2\\cdot x + 3\\cdot x^{2}\$"
+    p = Poly([1//2, 2//3, 1])
+    @test reprmime("text/latex", p) == "\$\\frac{1}{2} + \\frac{2}{3}\\cdot x + x^{2}\$"
+else
+    @test repr("text/latex", p) == "\$1 + 2\\cdot x + 3\\cdot x^{2}\$"
+    p = Poly([1//2, 2//3, 1])
+    @test repr("text/latex", p) == "\$\\frac{1}{2} + \\frac{2}{3}\\cdot x + x^{2}\$"
+end
 
 # customized printing with printpoly
 function printpoly_to_string(args...; kwargs...)


### PR DESCRIPTION
The function `endof` is now `lastindex` and `linspace` was substituted by
`range` using keyword arguments. Another change is from `reprmime` to `repr`.

In some cases simply using Compat was enough. In some of the tests,
the version number was explicitly called: I Compat wasn't enough.

There are still a few warnings when testing in v 0.7 in the tests that I can not figure out where they come from such as:

```
┌ Warning: `x ^ p::Integer` is deprecated, use `Base.power_by_squaring(x, p)` instead.
│   caller = @generated body at none:0 [inlined]
└ @ Core none:0
```

or 
```
┌ Warning: `conj(x)` is deprecated, use `x` instead.
│   caller = top-level scope
└ @ Core :0
```

Other than that the tests pass for version 0.6.2 and 0.7



