### PR TITLE
Fix more deprecations; drop Compat dep

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.6
-Compat 0.59.0
+julia 0.7

--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -1,25 +1,19 @@
 # Poly type manipulations
 
-VERSION < v"0.7.0-beta2.199" && __precompile__()
-
 module Polynomials
 #todo: sparse polynomials?
-
-using Compat
 
 export Poly, poly
 export degree, coeffs, variable, printpoly
 export polyval, polyint, polyder, roots, polyfit
 export Pade, padeval
 
-import Compat.lastindex
-
-import Base: length, size, eltype, collect, eachindex
+import Base: length, size, eltype, collect, eachindex, lastindex
 import Base: getindex, setindex!, copy, zero, one, convert, gcd
 import Base: show, print, *, /, //, -, +, ==, isapprox, divrem, div, rem, eltype
 import Base: promote_rule, truncate, chop,  conj, transpose, hash
 import Base: isequal
-import Compat.LinearAlgebra: norm, dot, eigvals, diagm, vecnorm, qrfact
+import LinearAlgebra: norm, dot, eigvals, diagm
 
 const SymbolLike = Union{AbstractString,Char,Symbol}
 
@@ -405,14 +399,14 @@ rem(num::Poly, den::Poly) = divrem(num, den)[2]
 ==(n::Number, p1::Poly) = (p1 == n)
 
 """
-    isapprox{T,S}(p1::Poly{T}, p2::Poly{S}; rtol::Real = Base.rtoldefault(T,S, 0), atol::Real = 0, norm::Function = vecnorm)
+    isapprox{T,S}(p1::Poly{T}, p2::Poly{S}; rtol::Real = Base.rtoldefault(T,S, 0), atol::Real = 0, norm::Function = norm)
 
 Truncate polynomials `p1` and `p2`, and compare the coefficient vectors using the
 given `norm` function. The tolerances `rtol` and `atol` are passed to both
 `truncate` and `isapprox`.
 """
 function isapprox(p1::Poly{T}, p2::Poly{S};
-  rtol::Real = (Base.rtoldefault(T,S, 0)), atol::Real = 0, norm::Function = vecnorm) where {T,S}
+  rtol::Real = (Base.rtoldefault(T,S, 0)), atol::Real = 0, norm::Function = norm) where {T,S}
   p1.var == p2.var || error("Polynomials must have same variable")
   p1t = truncate(p1; rtol = rtol, atol = atol)
   p2t = truncate(p2; rtol = rtol, atol = atol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,10 @@
 # assert file to test polynomial implementation
-using Compat
-using Compat.Test
-using Compat.LinearAlgebra
+using Test
+using LinearAlgebra
 using Polynomials
 using SpecialFunctions
 
-import Compat.SparseArrays: sparse, speye, nnz
+import SparseArrays: sparse, nnz
 
 pNULL = Poly(Float32[])
 p0 = Poly([0])
@@ -287,7 +286,7 @@ end
 function printpoly_to_string(args...; kwargs...)
     buf = IOBuffer()
     printpoly(buf, args...; kwargs...)
-    return Compat.String(take!(buf))
+    return String(take!(buf))
 end
 @test printpoly_to_string(Poly([1,2,3], "y")) == "1 + 2*y + 3*y^2"
 @test printpoly_to_string(Poly([1,2,3], "y"), descending_powers=true) == "3*y^2 + 2*y + 1"


### PR DESCRIPTION
Now that 0.7 is released and 1.0 is imminent, it seems like a good time to get rid of our Compat dependency. Do that and fix a couple of deprecations. Of course things will keep working with the old release on 0.6. Since ~200 packages depend recursively on Polynomials, I'm planning to merge this in short order to unblock packages on 1.0.