### PR TITLE
close issue 159

### DIFF
--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -560,11 +560,20 @@ function polyder(p::Poly{T}, order::Int=1) where {T}
   _polyder(p, order)
 end
 
+# _int(T) returns matching Integer type to T
+# to avoid overflow in `prod` usage below
+_int(::Type{T})  where {T <: Union{Integer, Int8, Int16, Int64, Int128, BigInt}} = T
+_int(::Type{Float16}) = Int16
+_int(::Type{Float32}) = Int32
+_int(::Type{Float64}) = Int64
+_int(::Type{BigFloat}) = BigInt
+_int(x) = Int
+
 function _polyder(p::Poly{T}, order::Int=1) where {T}
   n = length(p)
   a2 = Vector{T}(undef, n-order)
   for i = order:n-1
-    a2[i-order+1] = p[i] * prod((i-order+1):i)
+    a2[i-order+1] = p[i] * prod((one(_int(T)) * (i-order+1)):i)
   end
 
   return Poly(a2, p.var)

--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -560,20 +560,11 @@ function polyder(p::Poly{T}, order::Int=1) where {T}
   _polyder(p, order)
 end
 
-# _int(T) returns matching Integer type to T
-# to avoid overflow in `prod` usage below
-_int(::Type{T})  where {T <: Union{Integer, Int8, Int16, Int64, Int128, BigInt}} = T
-_int(::Type{Float16}) = Int16
-_int(::Type{Float32}) = Int32
-_int(::Type{Float64}) = Int64
-_int(::Type{BigFloat}) = BigInt
-_int(x) = Int
-
 function _polyder(p::Poly{T}, order::Int=1) where {T}
   n = length(p)
   a2 = Vector{T}(undef, n-order)
   for i = order:n-1
-    a2[i-order+1] = p[i] * prod((one(_int(T)) * (i-order+1)):i)
+    a2[i-order+1] = reduce(*, (i-order+1):i, init=p[i])
   end
 
   return Poly(a2, p.var)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -391,3 +391,5 @@ xx = Real[20.0, 30.0, 40.0]
 yy = Real[15.7696, 21.4851, 28.2463]
 polyfit(xx,yy,2)
 
+## Issue with overflow and polyder Issue #159
+@test !iszero(polyder(Poly(BigInt[0, 1])^100, 100))


### PR DESCRIPTION
This addresses overflow in polyder due to the taking of a large product by defining a method `_int` that returns an appropriate exponent type for the terms based on the polynomial type. It would be easier were there a function like `float(T)` or `complex(T)` already used in base.