### PR TITLE
fix docs plotting warning message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ jobs:
     - stage: "Documentation"
       julia: 1.4
       os: linux
+      env:
+        - GKSwstype="100"
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
         - julia --project=docs/ docs/make.jl


### PR DESCRIPTION
In the docs there are [warnings shown from GKS socket errors](https://juliamath.github.io/Polynomials.jl/dev/#Fitting-arbitrary-data-1), this environment variable tells GKS to run headless, suppressing those errors. 