### PR TITLE
V1.1.0: change  eltype(::Type{Polynomial}); improve ImmutablePolynomial; clean up

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "1.0.6"
+version = "1.1.0"
 
 [deps]
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -13,6 +13,9 @@ An abstract container for various polynomials.
 """
 abstract type AbstractPolynomial{T} end
 
+# We want  ⟒(P{α…,T}) = P{α…}; this default
+# works for most cases
+⟒(P::Type{<:AbstractPolynomial}) = constructorof(P)
 
 """
     Polynomials.@register(name)
@@ -36,9 +39,9 @@ macro register(name)
     quote
         Base.convert(::Type{P}, p::P) where {P<:$poly} = p
         Base.convert(P::Type{<:$poly}, p::$poly{T}) where {T} = P(coeffs(p), p.var)
-        Base.promote_rule(::Type{$poly{T}}, ::Type{$poly{S}}) where {T,S} =
+        Base.promote_rule(::Type{<:$poly{T}}, ::Type{<:$poly{S}}) where {T,S} =
             $poly{promote_type(T, S)}
-        Base.promote_rule(::Type{$poly{T}}, ::Type{S}) where {T,S<:Number} =
+        Base.promote_rule(::Type{<:$poly{T}}, ::Type{S}) where {T,S<:Number} =
             $poly{promote_type(T, S)}
         $poly(coeffs::AbstractVector{T}, var::SymbolLike = :x) where {T} =
             $poly{T}(coeffs, Symbol(var))

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -39,17 +39,18 @@ macro register(name)
     quote
         Base.convert(::Type{P}, p::P) where {P<:$poly} = p
         Base.convert(P::Type{<:$poly}, p::$poly{T}) where {T} = P(coeffs(p), p.var)
+        Base.promote(p::P, q::Q) where {T, P <:$poly{T}, Q <: $poly{T}} = p,q
         Base.promote_rule(::Type{<:$poly{T}}, ::Type{<:$poly{S}}) where {T,S} =
             $poly{promote_type(T, S)}
         Base.promote_rule(::Type{<:$poly{T}}, ::Type{S}) where {T,S<:Number} =
             $poly{promote_type(T, S)}
         $poly(coeffs::AbstractVector{T}, var::SymbolLike = :x) where {T} =
             $poly{T}(coeffs, Symbol(var))
-        $poly{T}(x::AbstractVector{S}, var = :x) where {T,S<:Number} =
-            $poly(T.(x), var)
-        $poly{T}(n::S, var = :x) where {T, S<:Number} =
-            $poly(T[n], var)
-        $poly(n::Number, var = :x) = $poly([n], var)
+        $poly{T}(x::AbstractVector{S}, var::SymbolLike = :x) where {T,S<:Number} =
+            $poly(T.(x), Symbol(var))
+        $poly{T}(n::S, var::SymbolLike = :x) where {T, S<:Number} =
+            $poly(T[n], Symbol(var))
+        $poly(n::Number, var::SymbolLike = :x) = $poly([n], Symbol(var))
         $poly{T}(var::SymbolLike=:x) where {T} = variable($poly{T}, Symbol(var))
         $poly(var::SymbolLike=:x) = variable($poly, Symbol(var))
     end
@@ -61,19 +62,20 @@ macro register1(name)
     poly = esc(name)
     quote
         Base.convert(::Type{P}, p::P) where {P<:$poly} = p
-        Base.promote_rule(::Type{$poly{α,T}}, ::Type{$poly{α,S}}) where {α,T,S} =
+        Base.promote(p::P, q::Q) where {α,T, P <:$poly{α,T}, Q <: $poly{α,T}} = p,q
+        Base.promote_rule(::Type{<:$poly{α,T}}, ::Type{<:$poly{α,S}}) where {α,T,S} =
             $poly{α,promote_type(T, S)}
-        Base.promote_rule(::Type{$poly{α,T}}, ::Type{S}) where {α,T,S<:Number} = 
+        Base.promote_rule(::Type{<:$poly{α,T}}, ::Type{S}) where {α,T,S<:Number} = 
             $poly{α,promote_type(T,S)}
-        function $poly{α,T}(x::AbstractVector{S}, var::Polynomials.SymbolLike = :x) where {α,T,S}
+        function $poly{α,T}(x::AbstractVector{S}, var::SymbolLike = :x) where {α,T,S}
             $poly{α,T}(T.(x), Symbol(var))
         end
-        $poly{α}(coeffs::AbstractVector{T}, var::Polynomials.SymbolLike=:x) where {α,T} =
+        $poly{α}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {α,T} =
             $poly{α,T}(coeffs, Symbol(var))
-        $poly{α,T}(n::Number, var::Polynomials.SymbolLike = :x) where {α,T} = n*one($poly{α,T}, Symbol(var))
-        $poly{α}(n::Number, var::Polynomials.SymbolLike = :x) where {α} = n*one($poly{α}, Symbol(var))
-        $poly{α,T}(var::Polynomials.SymbolLike=:x) where {α, T} = variable($poly{α,T}, Symbol(var))
-        $poly{α}(var::Polynomials.SymbolLike=:x) where {α} = variable($poly{α}, Symbol(var))
+        $poly{α,T}(n::Number, var::SymbolLike = :x) where {α,T} = n*one($poly{α,T}, Symbol(var))
+        $poly{α}(n::Number, var::SymbolLike = :x) where {α} = n*one($poly{α}, Symbol(var))
+        $poly{α,T}(var::SymbolLike=:x) where {α, T} = variable($poly{α,T}, Symbol(var))
+        $poly{α}(var::SymbolLike=:x) where {α} = variable($poly{α}, Symbol(var))
     end
 end
 
@@ -83,17 +85,18 @@ macro register2(name)
     poly = esc(name)
     quote
         Base.convert(::Type{P}, p::P) where {P<:$poly} = p
-        Base.promote_rule(::Type{$poly{α,β,T}}, ::Type{$poly{α,β,S}}) where {α,β,T,S} =
+        Base.promote(p::P, q::Q) where {α,β,T, P <:$poly{α,β,T}, Q <: $poly{α,β,T}} = p,q        
+        Base.promote_rule(::Type{<:$poly{α,β,T}}, ::Type{<:$poly{α,β,S}}) where {α,β,T,S} =
             $poly{α,β,promote_type(T, S)}
-        Base.promote_rule(::Type{$poly{α,β,T}}, ::Type{S}) where {α,β,T,S<:Number} =
+        Base.promote_rule(::Type{<:$poly{α,β,T}}, ::Type{S}) where {α,β,T,S<:Number} =
             $poly{α,β,promote_type(T, S)}
-        $poly{α,β}(coeffs::AbstractVector{T}, var::Polynomials.SymbolLike = :x) where {α,β,T} =
+        $poly{α,β}(coeffs::AbstractVector{T}, var::SymbolLike = :x) where {α,β,T} =
             $poly{α,β,T}(coeffs, Symbol(var))
-        $poly{α,β,T}(x::AbstractVector{S}, var = :x) where {α,β,T,S<:Number} = $poly{α,β,T}(T.(x), var)
-        $poly{α,β,T}(n::Number, var = :x) where {α,β,T} = n*one($poly{α,β,T}, var)
-        $poly{α,β}(n::Number, var = :x) where {α,β} = n*one($poly{α,β}, var)
-        $poly{α,β,T}(var=:x) where {α,β, T} = variable($poly{α,β,T}, var)
-        $poly{α,β}(var=:x) where {α,β} = variable($poly{α,β}, var)
+        $poly{α,β,T}(x::AbstractVector{S}, var::SymbolLike = :x) where {α,β,T,S<:Number} = $poly{α,β,T}(T.(x), var)
+        $poly{α,β,T}(n::Number, var::SymbolLike = :x) where {α,β,T} = n*one($poly{α,β,T}, Symbol(var))
+        $poly{α,β}(n::Number, va::SymbolLiker = :x) where {α,β} = n*one($poly{α,β}, Symbol(var))
+        $poly{α,β,T}(var::SymbolLike=:x) where {α,β, T} = variable($poly{α,β,T}, Symbol(var))
+        $poly{α,β}(var::SymbolLike=:x) where {α,β} = variable($poly{α,β}, Symbol(var))
     end
 end
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -172,7 +172,11 @@ In-place version of [`truncate`](@ref)
 """
 function truncate!(p::AbstractPolynomial{T};
     rtol::Real = Base.rtoldefault(real(T)),
-    atol::Real = 0,) where {T}
+                   atol::Real = 0,) where {T}
+
+    # 
+
+    
     max_coeff = maximum(abs, coeffs(p))
     thresh = max_coeff * rtol + atol
     map!(c->abs(c) <= thresh ? zero(T) : c, coeffs(p), coeffs(p))
@@ -392,7 +396,7 @@ Base.broadcastable(p::AbstractPolynomial) = Ref(p)
 function basis(::Type{P}, k::Int, _var::SymbolLike=:x; var=_var) where {P <: AbstractPolynomial}
     zs = zeros(Int, k+1)
     zs[end] = 1
-    P(zs, var)
+    ⟒(P){eltype(P)}(zs, var)
 end
 basis(p::P, k::Int, _var::SymbolLike=:x; var=_var) where {P<:AbstractPolynomial} = basis(P, k, var)
 
@@ -452,7 +456,7 @@ Base.hash(p::AbstractPolynomial, h::UInt) = hash(p.var, hash(coeffs(p), h))
 
 Returns a representation of 0 as the given polynomial.
 """
-Base.zero(::Type{P}, var=:x) where {P <: AbstractPolynomial} = P(zeros(eltype(P), 1), var)
+Base.zero(::Type{P}, var=:x) where {P <: AbstractPolynomial} = ⟒(P)(zeros(eltype(P), 1), var)
 Base.zero(p::P) where {P <: AbstractPolynomial} = zero(P, p.var)
 """
     one(::Type{<:AbstractPolynomial})
@@ -460,7 +464,7 @@ Base.zero(p::P) where {P <: AbstractPolynomial} = zero(P, p.var)
 
 Returns a representation of 1 as the given polynomial.
 """
-Base.one(::Type{P}, var=:x) where {P <: AbstractPolynomial} = P(ones(eltype(P),1), var)
+Base.one(::Type{P}, var=:x) where {P <: AbstractPolynomial} = ⟒(P)(ones(eltype(P),1), var)
 Base.one(p::P) where {P <: AbstractPolynomial} = one(P, p.var)
 
 Base.oneunit(::Type{P}, args...) where {P <: AbstractPolynomial} = one(P, args...)
@@ -556,11 +560,11 @@ Base.:(==)(p1::AbstractPolynomial, p2::AbstractPolynomial) =
 Base.:(==)(p::AbstractPolynomial, n::Number) = degree(p) <= 0 && p[0] == n
 Base.:(==)(n::Number, p::AbstractPolynomial) = p == n
 
+
 function Base.isapprox(p1::AbstractPolynomial{T},
     p2::AbstractPolynomial{S};
     rtol::Real = (Base.rtoldefault(T, S, 0)),
-                       atol::Real = 0,) where {T,S}
-    
+    atol::Real = 0,) where {T,S}
     p1, p2 = promote(p1, p2)
     check_same_variable(p1, p2)  || error("p1 and p2 must have same var")
     p1t = truncate(p1; rtol = rtol, atol = atol)
@@ -569,7 +573,6 @@ function Base.isapprox(p1::AbstractPolynomial{T},
         return false
     end
     isapprox(coeffs(p1t), coeffs(p2t), rtol = rtol, atol = atol)
-    
 end
 
 function Base.isapprox(p1::AbstractPolynomial{T},
@@ -582,6 +585,7 @@ function Base.isapprox(p1::AbstractPolynomial{T},
     end
     isapprox(coeffs(p1t), [n], rtol = rtol, atol = atol)
 end
+
 
 Base.isapprox(n::S,
     p1::AbstractPolynomial{T};

--- a/src/common.jl
+++ b/src/common.jl
@@ -229,33 +229,7 @@ function Base.chop(p::AbstractPolynomial{T};
 end
 
 
-"""
-    variable(var=:x)
-    variable(::Type{<:AbstractPolynomial}, var=:x)
-    variable(p::AbstractPolynomial, var=p.var)
 
-Return the monomial `x` in the indicated polynomial basis.  If no type is give, will default to [`Polynomial`](@ref). Equivalent  to  `P(var)`.
-
-# Examples
-```jldoctest  common
-julia> using Polynomials
-
-julia> x = variable()
-Polynomial(x)
-
-julia> p = 100 + 24x - 3x^2
-Polynomial(100 + 24*x - 3*x^2)
-
-julia> roots((x - 3) * (x + 2))
-2-element Array{Float64,1}:
- -2.0
-  3.0
-
-```
-"""
-variable(::Type{P}, var::SymbolLike = :x) where {P <: AbstractPolynomial} = MethodError()
-variable(p::AbstractPolynomial, var::SymbolLike = p.var) = variable(typeof(p), var)
-variable(var::SymbolLike = :x) = variable(Polynomial{Int}, var)
 
 """
     check_same_variable(p::AbstractPolynomial, q::AbstractPolynomial)
@@ -388,18 +362,6 @@ Base.lastindex(p::AbstractPolynomial) = length(p) - 1
 Base.eachindex(p::AbstractPolynomial) = 0:length(p) - 1
 Base.broadcastable(p::AbstractPolynomial) = Ref(p)
 
-# basis
-# var is a positional argument, not a keyword; can't deprecate so we do `_var; var=_var`
-#@deprecate basis(p::P, k::Int; var=:x)  where {P<:AbstractPolynomial}  basis(p, k, var)
-#@deprecate basis(::Type{P}, k::Int; var=:x) where {P <: AbstractPolynomial} basis(P, k,var)
-# return the kth basis polynomial for the given polynomial type, e.g. x^k for Polynomial{T}
-function basis(::Type{P}, k::Int, _var::SymbolLike=:x; var=_var) where {P <: AbstractPolynomial}
-    zs = zeros(Int, k+1)
-    zs[end] = 1
-    ⟒(P){eltype(P)}(zs, var)
-end
-basis(p::P, k::Int, _var::SymbolLike=:x; var=_var) where {P<:AbstractPolynomial} = basis(P, k, var)
-
 
 
 
@@ -450,6 +412,9 @@ Base.setindex!(p::AbstractPolynomial, values, ::Colon) =
 identity =#
 Base.copy(p::P) where {P <: AbstractPolynomial} = P(copy(coeffs(p)), p.var)
 Base.hash(p::AbstractPolynomial, h::UInt) = hash(p.var, hash(coeffs(p), h))
+
+#=
+zero, one, variable, basis =#
 """
     zero(::Type{<:AbstractPolynomial})
     zero(::AbstractPolynomial)
@@ -469,6 +434,47 @@ Base.one(p::P) where {P <: AbstractPolynomial} = one(P, p.var)
 
 Base.oneunit(::Type{P}, args...) where {P <: AbstractPolynomial} = one(P, args...)
 Base.oneunit(p::P, args...) where {P <: AbstractPolynomial} = one(p, args...)
+
+
+"""
+    variable(var=:x)
+    variable(::Type{<:AbstractPolynomial}, var=:x)
+    variable(p::AbstractPolynomial, var=p.var)
+
+Return the monomial `x` in the indicated polynomial basis.  If no type is give, will default to [`Polynomial`](@ref). Equivalent  to  `P(var)`.
+
+# Examples
+```jldoctest  common
+julia> using Polynomials
+
+julia> x = variable()
+Polynomial(x)
+
+julia> p = 100 + 24x - 3x^2
+Polynomial(100 + 24*x - 3*x^2)
+
+julia> roots((x - 3) * (x + 2))
+2-element Array{Float64,1}:
+ -2.0
+  3.0
+
+```
+"""
+variable(::Type{P}, var::SymbolLike = :x) where {P <: AbstractPolynomial} = MethodError()
+variable(p::AbstractPolynomial, var::SymbolLike = p.var) = variable(typeof(p), var)
+variable(var::SymbolLike = :x) = variable(Polynomial{Int}, var)
+
+# basis
+# var is a positional argument, not a keyword; can't deprecate so we do `_var; var=_var`
+#@deprecate basis(p::P, k::Int; var=:x)  where {P<:AbstractPolynomial}  basis(p, k, var)
+#@deprecate basis(::Type{P}, k::Int; var=:x) where {P <: AbstractPolynomial} basis(P, k,var)
+# return the kth basis polynomial for the given polynomial type, e.g. x^k for Polynomial{T}
+function basis(::Type{P}, k::Int, _var::SymbolLike=:x; var=_var) where {P <: AbstractPolynomial}
+    zs = zeros(Int, k+1)
+    zs[end] = 1
+    ⟒(P){eltype(P)}(zs, var)
+end
+basis(p::P, k::Int, _var::SymbolLike=:x; var=_var) where {P<:AbstractPolynomial} = basis(P, k, var)
 
 #=
 arithmetic =#

--- a/src/common.jl
+++ b/src/common.jl
@@ -173,10 +173,6 @@ In-place version of [`truncate`](@ref)
 function truncate!(p::AbstractPolynomial{T};
     rtol::Real = Base.rtoldefault(real(T)),
                    atol::Real = 0,) where {T}
-
-    # 
-
-    
     max_coeff = maximum(abs, coeffs(p))
     thresh = max_coeff * rtol + atol
     map!(c->abs(c) <= thresh ? zero(T) : c, coeffs(p), coeffs(p))
@@ -361,10 +357,6 @@ Base.firstindex(p::AbstractPolynomial) = 0
 Base.lastindex(p::AbstractPolynomial) = length(p) - 1
 Base.eachindex(p::AbstractPolynomial) = 0:length(p) - 1
 Base.broadcastable(p::AbstractPolynomial) = Ref(p)
-
-
-
-
 
 # iteration
 # iteration occurs over the basis polynomials
@@ -566,7 +558,6 @@ Base.:(==)(p1::AbstractPolynomial, p2::AbstractPolynomial) =
 Base.:(==)(p::AbstractPolynomial, n::Number) = degree(p) <= 0 && p[0] == n
 Base.:(==)(n::Number, p::AbstractPolynomial) = p == n
 
-
 function Base.isapprox(p1::AbstractPolynomial{T},
     p2::AbstractPolynomial{S};
     rtol::Real = (Base.rtoldefault(T, S, 0)),
@@ -591,7 +582,6 @@ function Base.isapprox(p1::AbstractPolynomial{T},
     end
     isapprox(coeffs(p1t), [n], rtol = rtol, atol = atol)
 end
-
 
 Base.isapprox(n::S,
     p1::AbstractPolynomial{T};

--- a/src/contrib.jl
+++ b/src/contrib.jl
@@ -33,11 +33,14 @@ end
 ## Slight modification when `x` is a matrix
 ## Remove once dependencies for Julia 1.0.0 are dropped
 function evalpoly(x::S, p::Tuple) where {S}
+    p == () && return zero(S)
     if @generated
         N = length(p.parameters)
         ex = :(p[end]*_one(S))
-        for i in N-1:-1:1
-            ex = :(_muladd(x, $ex, p[$i]))
+        if N > 0
+            for i in N-1:-1:1
+                ex = :(_muladd(x, $ex, p[$i]))
+            end
         end
         ex
     else

--- a/src/contrib.jl
+++ b/src/contrib.jl
@@ -37,10 +37,8 @@ function evalpoly(x::S, p::Tuple) where {S}
     if @generated
         N = length(p.parameters)
         ex = :(p[end]*_one(S))
-        if N > 0
-            for i in N-1:-1:1
-                ex = :(_muladd(x, $ex, p[$i]))
-            end
+        for i in N-1:-1:1
+            ex = :(_muladd(x, $ex, p[$i]))
         end
         ex
     else

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -59,7 +59,7 @@ function Base.convert(C::Type{<:ChebyshevT}, p::Polynomial)
 end
 
 domain(::Type{<:ChebyshevT}) = Interval(-1, 1)
-
+variable(P::Type{<:ChebyshevT}, var::SymbolLike=:x ) = P([0,1], var)
 """
     (::ChebyshevT)(x)
 

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -124,10 +124,10 @@ end
 # overrides from common.jl due to coeffs possibly being padded, coeffs being non mutable, ...
 
 ## promote N,M case; may not change p,q if T==S
-function Base.promote(p::ImmutablePolynomial{T,N}, q::ImmutablePolynomial{S,M}) where {N,T,M,S}
-    R = promote_type(T,S)
-    ImmutablePolynomial{R}(p.coeffs, p.var), ImmutablePolynomial{R}(q.coeffs, q.var)
-end
+#function Base.promote(p::ImmutablePolynomial{T,N}, q::ImmutablePolynomial{S,M}) where {N,T,M,S}
+#    R = promote_type(T,S)
+#    ImmutablePolynomial{R}(p.coeffs, p.var), ImmutablePolynomial{R}(q.coeffs, q.var)
+#end
 
 Base.collect(p::P) where {P <: ImmutablePolynomial} = [pᵢ for pᵢ ∈ p]
 

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -158,8 +158,8 @@ Base.hash(p::LaurentPolynomial, h::UInt) = hash(p.var, hash(range(p), hash(coeff
 
 degree(p::LaurentPolynomial) = p.n[]
 isconstant(p::LaurentPolynomial) = range(p) == 0:0
-basis(P::Type{<:LaurentPolynomial{T}}, n::Int, var=:x) where{T} = LaurentPolynomial(ones(T,1), n:n, var)
-basis(P::Type{LaurentPolynomial}, n::Int, var=:x) = LaurentPolynomial(ones(Float64, 1), n:n, var)
+basis(P::Type{<:LaurentPolynomial{T}}, n::Int, var::SymbolLike=:x) where{T} = LaurentPolynomial(ones(T,1), n:n, var)
+basis(P::Type{LaurentPolynomial}, n::Int, var::SymbolLike=:x) = LaurentPolynomial(ones(Float64, 1), n:n, var)
 
 Base.zero(::Type{LaurentPolynomial{T}},  var=Symbollike=:x) where {T} =  LaurentPolynomial{T}(zeros(T,1),  0:0, Symbol(var))
 Base.zero(::Type{LaurentPolynomial},  var=Symbollike=:x) =  zero(LaurentPolynomial{Float64}, var)
@@ -259,7 +259,10 @@ function showterm(io::IO, ::Type{<:LaurentPolynomial}, pj::T, var, j, first::Boo
         printcoefficient(io, pj, j, mimetype)
     end
     printproductsign(io, pj, j, mimetype)
-    unicode_exponent(io, var, j)
+    iszero(j) && return
+    print(io, var)
+    j ==1  && return
+    unicode_exponent(io, j)
     return true
 end
 

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -259,9 +259,9 @@ function showterm(io::IO, ::Type{<:LaurentPolynomial}, pj::T, var, j, first::Boo
         printcoefficient(io, pj, j, mimetype)
     end
     printproductsign(io, pj, j, mimetype)
-    iszero(j) && return
+    iszero(j) && return  true
     print(io, var)
-    j ==1  && return
+    j ==1  && return  true
     unicode_exponent(io, j)
     return true
 end

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -43,6 +43,11 @@ Base.zero(::Type{<:Poly{T}},var=:x)  where {T} = Poly{T}(zeros(T,0), var)
 Base.zero(::Type{<:Poly},var=:x)  where {T} = Poly(zeros(Float64,0), var)
 Base.one(::Type{<:Poly{T}},var=:x)  where {T} = Poly{T}(ones(T,1), var)
 Base.one(::Type{<:Poly},var=:x)  where {T} = Poly(ones(Float64,1), var)
+function Polynomials.basis(P::Type{<:Poly}, k::Int, _var::Polynomials.SymbolLike=:x; var=_var) 
+    zs = zeros(Int, k+1)
+    zs[end] = 1
+    P(zs, var)
+end
 
 function (p::Poly{T})(x::S) where {T,S}
     oS = one(x)

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -38,6 +38,12 @@ Polynomials.@register Poly
 
 Base.convert(P::Type{<:Polynomial}, p::Poly{T}) where {T} = P(p.coeffs, p.var)
 
+Base.eltype(P::Type{<:Poly}) = P
+Base.zero(::Type{<:Poly{T}},var=:x)  where {T} = Poly{T}(zeros(T,0), var)
+Base.zero(::Type{<:Poly},var=:x)  where {T} = Poly(zeros(Float64,0), var)
+Base.one(::Type{<:Poly{T}},var=:x)  where {T} = Poly{T}(ones(T,1), var)
+Base.one(::Type{<:Poly},var=:x)  where {T} = Poly(ones(Float64,1), var)
+
 function (p::Poly{T})(x::S) where {T,S}
     oS = one(x)
     length(p) == 0 && return zero(T) *  oS
@@ -52,7 +58,7 @@ end
 function Base.:+(p1::Poly, p2::Poly)
     p1.var != p2.var && error("Polynomials must have same variable")
     n = max(length(p1), length(p2))
-    c = [p1[i] + p2[i] for i = 0:n]
+    c = [p1[i] + p2[i] for i = 0:n-1]
     return Poly(c, p1.var)
 end
 

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -96,7 +96,7 @@ function isconstant(p::SparsePolynomial)
     return true
 end
 
-basis(P::Type{<:SparsePolynomial}, n::Int, var=:x) =
+basis(P::Type{<:SparsePolynomial}, n::Int, var::SymbolLike=:x) =
     SparsePolynomial(Dict(n=>one(eltype(one(P)))), var)
 
 # return coeffs as  a vector

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -2,7 +2,6 @@ abstract type StandardBasisPolynomial{T} <: AbstractPolynomial{T} end
 
 
 
-
 function showterm(io::IO, ::Type{<:StandardBasisPolynomial}, pj::T, var, j, first::Bool, mimetype) where {T} 
     if iszero(pj) return false end
     pj = printsign(io, pj, first, mimetype)
@@ -13,7 +12,6 @@ function showterm(io::IO, ::Type{<:StandardBasisPolynomial}, pj::T, var, j, firs
     printexponent(io, var, j, mimetype)
     return true
 end
-
 
 # allows  broadcast  issue #209
 evalpoly(x, p::StandardBasisPolynomial) = p(x)

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -1,6 +1,9 @@
 abstract type StandardBasisPolynomial{T} <: AbstractPolynomial{T} end
 
-const ⟒ = constructorof #\upin
+# We want  ⟒(P{α…,T}) = P{α…}
+# For StandardBasisPolynomials this is
+⟒(P::Type{<:StandardBasisPolynomial}) = constructorof(P)
+
 
 
 function showterm(io::IO, ::Type{<:StandardBasisPolynomial}, pj::T, var, j, first::Bool, mimetype) where {T} 
@@ -14,6 +17,7 @@ function showterm(io::IO, ::Type{<:StandardBasisPolynomial}, pj::T, var, j, firs
     return true
 end
 
+
 # allows  broadcast  issue #209
 evalpoly(x, p::StandardBasisPolynomial) = p(x)
 
@@ -24,6 +28,8 @@ mapdomain(::Type{<:StandardBasisPolynomial}, x::AbstractArray) = x
 isconstant(p::StandardBasisPolynomial) = degree(p) <= 0
 
 Base.convert(P::Type{<:StandardBasisPolynomial}, q::StandardBasisPolynomial) = isa(q, P) ? q : P([q[i] for i in 0:degree(q)], q.var)
+
+variable(::Type{P}, var::SymbolLike = :x) where {P <: StandardBasisPolynomial} = P([0, 1], var)
 
 function fromroots(P::Type{<:StandardBasisPolynomial}, r::AbstractVector{T}; var::SymbolLike = :x) where {T <: Number}
     n = length(r)
@@ -45,9 +51,9 @@ function Base.:+(p::P, c::S) where {T, P <: StandardBasisPolynomial{T}, S<:Numbe
 end
 
 
-function derivative(p::P, order::Integer = 1) where {P <: StandardBasisPolynomial}
+function derivative(p::P, order::Integer = 1) where {T, P <: StandardBasisPolynomial{T}}
     order < 0 && error("Order of derivative must be non-negative")
-    T = eltype(p)
+
     # we avoid usage like Base.promote_op(*, T, Int) here, say, as
     # Base.promote_op(*, Rational, Int) is Any, not Rational in analogy to
     # Base.promote_op(*, Complex, Int)
@@ -66,8 +72,8 @@ function derivative(p::P, order::Integer = 1) where {P <: StandardBasisPolynomia
 end
 
 
-function integrate(p::P, k::S) where {P <: StandardBasisPolynomial, S<:Number}
-    T = eltype(p)
+function integrate(p::P, k::S) where {T, P <: StandardBasisPolynomial{T}, S<:Number}
+
     R = eltype((one(T)+one(S))/1)
     if hasnan(p) || isnan(k)
         return ⟒(P)([NaN])
@@ -82,7 +88,7 @@ function integrate(p::P, k::S) where {P <: StandardBasisPolynomial, S<:Number}
 end
 
 
-function Base.divrem(num::P, den::Q) where {P <: StandardBasisPolynomial, Q <: StandardBasisPolynomial}
+function Base.divrem(num::P, den::Q) where {T, P <: StandardBasisPolynomial{T}, S, Q <: StandardBasisPolynomial{S}}
 
     check_same_variable(num, den) || error("Polynomials must have same variable")
     var = num.var
@@ -94,7 +100,6 @@ function Base.divrem(num::P, den::Q) where {P <: StandardBasisPolynomial, Q <: S
     m == -1 && throw(DivideError())
     if m == 0 && den[0] ≈ 0 throw(DivideError()) end
     
-    T, S =  eltype(num), eltype(den)
     R = eltype(one(T)/one(S))
 
     deg = n - m + 1
@@ -120,13 +125,12 @@ function Base.divrem(num::P, den::Q) where {P <: StandardBasisPolynomial, Q <: S
 end
 
 
-function companion(p::P) where {P <: StandardBasisPolynomial}
+function companion(p::P) where {T, P <: StandardBasisPolynomial{T}}
     d = length(p) - 1
     d < 1 && error("Series must have degree greater than 1")
     d == 1 && return diagm(0 => [-p[0] / p[1]])
 
     
-    T = eltype(p)
     R = eltype(one(T)/one(T))
     
     comp = diagm(-1 => ones(R, d - 1))
@@ -137,8 +141,8 @@ function companion(p::P) where {P <: StandardBasisPolynomial}
     return comp
 end
 
-function  roots(p::P; kwargs...)  where  {P <: StandardBasisPolynomial}
-    T = eltype(p)
+function  roots(p::P; kwargs...)  where  {T, P <: StandardBasisPolynomial{T}}
+
     R = eltype(one(T)/one(T))    
     d = degree(p)
     if d < 1

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -1,8 +1,5 @@
 abstract type StandardBasisPolynomial{T} <: AbstractPolynomial{T} end
 
-# We want  ⟒(P{α…,T}) = P{α…}
-# For StandardBasisPolynomials this is
-⟒(P::Type{<:StandardBasisPolynomial}) = constructorof(P)
 
 
 
@@ -59,10 +56,10 @@ function derivative(p::P, order::Integer = 1) where {T, P <: StandardBasisPolyno
     # Base.promote_op(*, Complex, Int)
     R = eltype(one(T)*1) 
     order == 0 && return p
-    hasnan(p) && return P(R[NaN], p.var)
-    order > length(p) && return P(R[0], p.var)
+    hasnan(p) && return ⟒(P){R}(R[NaN], p.var)
+    order > length(p) && return zero(⟒(P){R},p.var)
     d = degree(p)
-    d <= 0 && return zero(p)
+    d <= 0 && return zero(⟒(P){R},p.var)
     n = d + 1
     a2 = Vector{R}(undef, n - order)
     @inbounds for i in order:n - 1

--- a/src/show.jl
+++ b/src/show.jl
@@ -239,11 +239,15 @@ function printexponent(io, var, i, mimetype::MIME)
     end
 end
 
-function unicode_exponent(io, var, j)
-    iszero(j) && return
-    print(io, var)
-    j ==1  && return
+function unicode_exponent(io, j)
     a = ("⁻","","","⁰","¹","²","³","⁴","⁵","⁶","⁷","⁸","⁹")
+    for i in string(j)
+        print(io, a[Int(i)-44])
+    end
+end
+
+function unicode_subscript(io, j)
+    a = ("⁻","","","₀","₁","₂","₃","₄","₅","₆","₇","₈","₉")
     for i in string(j)
         print(io, a[Int(i)-44])
     end

--- a/src/show.jl
+++ b/src/show.jl
@@ -247,7 +247,7 @@ function unicode_exponent(io, j)
 end
 
 function unicode_subscript(io, j)
-    a = ("⁻","","","₀","₁","₂","₃","₄","₅","₆","₇","₈","₉")
+    a = ("₋","","","₀","₁","₂","₃","₄","₅","₆","₇","₈","₉")
     for i in string(j)
         print(io, a[Int(i)-44])
     end


### PR DESCRIPTION
* changed `eltype(P::Type{<:AbstractPolynomial{T}})`  to be `T` with default of  `Float64` from `P`. (Though not  for legacy `Poly` type). Getting the eltype from the type is  at times required and  this avoids a  hack such as `typeof(one(P))`. This is  in line with a view  that a  polynomial is like `Vector{T}` (for which `eltype` returns `T`) with indexing and arithmetic modifications.  This allows clean up of some constructors (`zero`,  `one`,  `variable`, and `basis`).

* For `ImmutablePolynomial` reversed the order of parameters  from `N,T`  (matching  `NTuple`)  to  `T,N` so that  the `register` macro  can   be  used. Also  `N` as `degree+1`  is  enforced (leading  term is non-zero; zero polynomial is empty). The  latter allows generated functions to be used in many cases for  `+`, as  it was  for  `*`.  In a simple  benchmarking  script  we now have ImmutablePolynomials faster for evaluation, addition, multiplication, and scalar addition and multiplication. This change allowed some tests  to  be relaxed to   include  ImmutablePolynomial.
