### PR TITLE
closes issue #214; close issue #215; adjust register macros

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "1.1.1"
+version = "1.1.0"
 
 [deps]
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"

--- a/src/common.jl
+++ b/src/common.jl
@@ -90,8 +90,16 @@ fit(P::Type{<:AbstractPolynomial},
     y,
     deg::Integer = length(x) - 1;
     weights = nothing,
-    var = :x,) = fit(P, promote(collect(x), collect(y))..., deg; weights = weights, var = var)
+    var = :x,) = fit'(P, promote(collect(x), collect(y))..., deg; weights = weights, var = var)
 
+#  avoid issue  214
+fit′(P::Type{<:AbstractPolynomial}, x, y, args...;kwargs...) = throw(MethodError("x and y do not produce abstract   vectors"))
+fit′(P::Type{<:AbstractPolynomial},
+     x::AbstractVector{T},
+     y::AbstractVector{T},
+     args...; kwargs...) where {T} = fit(P,x,y,args...;  kwargs...)
+         
+         
 fit(x::AbstractVector,
     y::AbstractVector,
     deg::Integer = length(x) - 1;
@@ -249,7 +257,8 @@ LinearAlgebra.norm(q::AbstractPolynomial, p::Real = 2) = norm(coeffs(q), p)
 
 Returns the complex conjugate of the polynomial
 """
-LinearAlgebra.conj(p::P) where {P <: AbstractPolynomial} = P(conj(coeffs(p)))
+LinearAlgebra.conj(p::P) where {P <: AbstractPolynomial} = ⟒(P)(conj(coeffs(p)), p.var)
+LinearAlgebra.adjoint(p::P) where {P <: AbstractPolynomial} = ⟒(P)(adjoint.(coeffs(p)), p.var)
 LinearAlgebra.transpose(p::AbstractPolynomial) = p
 LinearAlgebra.transpose!(p::AbstractPolynomial) = p
 

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -286,6 +286,9 @@ end
         yy = Real[15.7696, 21.4851, 28.2463]
         fit(P, xx, yy, 2)
 
+        # issue #214 --  should error
+        @test_throws MethodError fit(Polynomial, rand(2,2), rand(2,2))
+
     end
 end
 
@@ -574,6 +577,8 @@ end
         @test coeffs(p2) ==ᵗ⁰ [1 + 1im, 2 + 3im]
         @test transpose(p) == p
         P != ImmutablePolynomial && @test transpose!(p) == p
+        @test adjoint(Polynomial(im)) == Polynomial(-im) # issue 215
+        @test conj(Polynomial(im)) == Polynomial(-im) # issue 215
         
         @test norm(P([1., 2.])) == norm([1., 2.])
         @test norm(P([1., 2.]), 1) == norm([1., 2.], 1)


### PR DESCRIPTION
Close issue #214 by  routing promoted x,y values through function to  control dispatch

Close issue #215 by addressing `conj` issue with `Complex{Bool}`  type; added `adjoint`

Clean   up undocumented macros for *potential* usage of framework with parameterized families. (Should these just be removed?)