### PR TITLE
WIP:  Issue 231. Don't merge

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -399,15 +399,15 @@ function Base.setindex!(p::AbstractPolynomial, value, idx::Int)
     return p
 end
 
-Base.setindex!(p::AbstractPolynomial, value::Number, idx::Number) =
+Base.setindex!(p::AbstractPolynomial, value, idx::Number) =
     setindex!(p, value, convert(Int, idx))
-Base.setindex!(p::AbstractPolynomial, value::Number, indices) =
+Base.setindex!(p::AbstractPolynomial, value, indices) =
     [setindex!(p, value, i) for i in indices]
-Base.setindex!(p::AbstractPolynomial, values, indices) =
+Base.setindex!(p::AbstractPolynomial, values::Union{Tuple,AbstractArray}, indices) =
     [setindex!(p, v, i) for (v, i) in zip(values, indices)]
-Base.setindex!(p::AbstractPolynomial, value::Number, ::Colon) =
+Base.setindex!(p::AbstractPolynomial, value, ::Colon) =
     setindex!(p, value, eachindex(p))
-Base.setindex!(p::AbstractPolynomial, values, ::Colon) =
+Base.setindex!(p::AbstractPolynomial, values::Union{Tuple,AbstractArray}, ::Colon) =
     [setindex!(p, v, i) for (v, i) in zip(values, eachindex(p))]
 
 #=

--- a/src/common.jl
+++ b/src/common.jl
@@ -153,7 +153,7 @@ vander(::Type{<:AbstractPolynomial}, x::AbstractVector, deg::Integer)
 
 Returns the indefinite integral of the polynomial with constant `C`.
 """
-integrate(p::AbstractPolynomial, C::Number = 0) = integrate(p, C)
+integrate(p::AbstractPolynomial, C = 0) = integrate(p, C)
 
 """
     integrate(::AbstractPolynomial, a, b)
@@ -322,9 +322,10 @@ isconstant(p::AbstractPolynomial) = degree(p) <= 0
 
 
 
-
-hasnan(p::AbstractPolynomial) = any(isnan.(coeffs(p)))
-
+hasnan(x::AbstractFloat)  =  isnan(x)
+hasnan(x::Number)  = false
+hasnan(x::AbstractArray) = any(hasnan.(x))
+hasnan(p::AbstractPolynomial) = any(hasnan(c) for c  in coeffs(p))
 """
     domain(::Type{<:AbstractPolynomial})
 
@@ -388,7 +389,7 @@ Base.getindex(p::AbstractPolynomial, indices) = [getindex(p, i) for i in indices
 Base.getindex(p::AbstractPolynomial, ::Colon) = coeffs(p)
 
 # setindex
-function Base.setindex!(p::AbstractPolynomial, value::Number, idx::Int)
+function Base.setindex!(p::AbstractPolynomial, value, idx::Int)
     n = length(coeffs(p))
     if n ≤ idx
         resize!(p.coeffs, idx + 1)

--- a/src/contrib.jl
+++ b/src/contrib.jl
@@ -117,6 +117,23 @@ _one(P::Type{<:Matrix}) = one(eltype(P))*I
 _one(x::Matrix) = one(eltype(x))*I
 _one(x) = one(x)
 
+
+#  Type piracy
+_one(x::Vector) = NaN
+_one(::Type{P}) where {P <: Vector} = NaN
+
+# match shape
+function _zeros(p1, n)
+    [0*p1[0] for  _ in  1:n]
+end
+
+function _zeros(p1,p2, n)
+    [0*p1[0] .+ 0*p2[0] for _ in 1:n]
+end
+
+# _zero(p::AbstractPolynomial) = 0*p[0]
+# _zero(p::T) where  {T} = zero(T)
+
 ## get type of parametric composite type without type parameters
 ## this is needed when the underlying type changes, e.g. with integration
 ## where T=Int might become T=Float64

--- a/src/contrib.jl
+++ b/src/contrib.jl
@@ -106,6 +106,7 @@ function _evalpoly(z::Complex, p)
     muladd(ai, z, b)
 end
 
+## Avoid type piracy
 ## modify muladd, as needed
 _muladd(a,b,c) = muladd(a,b,c)
 _muladd(a::Vector, b, c) = a.*b .+ c
@@ -117,22 +118,8 @@ _one(P::Type{<:Matrix}) = one(eltype(P))*I
 _one(x::Matrix) = one(eltype(x))*I
 _one(x) = one(x)
 
-
-#  Type piracy
-_one(x::Vector) = NaN
-_one(::Type{P}) where {P <: Vector} = NaN
-
-# match shape
-function _zeros(p1, n)
-    [0*p1[0] for  _ in  1:n]
-end
-
-function _zeros(p1,p2, n)
-    [0*p1[0] .+ 0*p2[0] for _ in 1:n]
-end
-
-# _zero(p::AbstractPolynomial) = 0*p[0]
-# _zero(p::T) where  {T} = zero(T)
+_isone(x) = isone(x)
+_isone(x::Vector) = false
 
 ## get type of parametric composite type without type parameters
 ## this is needed when the underlying type changes, e.g. with integration

--- a/src/polynomials/Polynomial.jl
+++ b/src/polynomials/Polynomial.jl
@@ -116,8 +116,9 @@ function Base.:*(p1::Polynomial{T}, p2::Polynomial{S}) where {T,S}
     n, m = length(p1)-1, length(p2)-1 # not degree, so pNULL works
     if n > 0 && m > 0
         p1.var != p2.var && error("Polynomials must have same variable")
-        R = promote_type(T, S)
-        c = _zeros(p1,p2, m + n + 1)
+        #R = promote_type(T, S)
+        #c = zeros(R, m+n+1)
+        c = [0*p1[0]*p2[0]  for _  in  1:m+n+1] 
         for i in 0:n, j in 0:m
             @inbounds c[i + j + 1] += p1[i] * p2[j]
         end

--- a/src/polynomials/Polynomial.jl
+++ b/src/polynomials/Polynomial.jl
@@ -130,3 +130,9 @@ function Base.:*(p1::Polynomial{T}, p2::Polynomial{S}) where {T,S}
     end
 
 end
+
+function fromroots(p::Type{P}, r::AbstractVector{T}; var::SymbolLike = :x) where {T, P  <: Polynomial}
+    isempty(r)  && return ⟒(P)([one(T)], var)
+    x = variable(⟒(P)([one(first(r))], var))
+    return prod(x - rᵢ for rᵢ in r)
+end

--- a/src/polynomials/Polynomial.jl
+++ b/src/polynomials/Polynomial.jl
@@ -1,7 +1,7 @@
 export Polynomial
 
 """
-    Polynomial{T<:Number}(coeffs::AbstractVector{T}, var=:x)
+    Polynomial{T}(coeffs::AbstractVector{T}, var=:x)
 
 Construct a polynomial from its coefficients `a`, lowest order first, optionally in
 terms of the given variable `x`. `x` can be a character, symbol, or string.
@@ -29,12 +29,13 @@ Polynomial(1 + 2*s + 3*s^2)
 
 julia> one(Polynomial)
 Polynomial(1.0)
+
 ```
 """
-struct Polynomial{T <: Number} <: StandardBasisPolynomial{T}
+struct Polynomial{T} <: StandardBasisPolynomial{T}
     coeffs::Vector{T}
     var::Symbol
-    function Polynomial{T}(coeffs::Vector{T}, var::Symbol) where {T <: Number}
+    function Polynomial{T}(coeffs::Vector{T}, var::Symbol) where {T}
         length(coeffs) == 0 && return new{T}(zeros(T, 1), var)
         last_nz = findlast(!iszero, coeffs)
         last = max(1, last_nz === nothing ? 0 : last_nz)
@@ -116,7 +117,7 @@ function Base.:*(p1::Polynomial{T}, p2::Polynomial{S}) where {T,S}
     if n > 0 && m > 0
         p1.var != p2.var && error("Polynomials must have same variable")
         R = promote_type(T, S)
-        c = zeros(R, m + n + 1)
+        c = _zeros(p1,p2, m + n + 1)
         for i in 0:n, j in 0:m
             @inbounds c[i + j + 1] += p1[i] * p2[j]
         end

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -5,7 +5,7 @@ abstract type StandardBasisPolynomial{T} <: AbstractPolynomial{T} end
 function showterm(io::IO, ::Type{<:StandardBasisPolynomial}, pj::T, var, j, first::Bool, mimetype) where {T} 
     if iszero(pj) return false end
     pj = printsign(io, pj, first, mimetype)
-    if !(pj == one(T) && !(showone(T) || j == 0))
+    if !(isone(pj) && !(showone(T) || iszero(j)))
         printcoefficient(io, pj, j, mimetype)
     end
     printproductsign(io, pj, j, mimetype)
@@ -38,7 +38,7 @@ function fromroots(P::Type{<:StandardBasisPolynomial}, r::AbstractVector{T}; var
 end
 
 
-function Base.:+(p::P, c::S) where {T, P <: StandardBasisPolynomial{T}, S<:Number}
+function Base.:+(p::P, c::S) where {T, P <: StandardBasisPolynomial{T}, S}
     R = promote_type(T,S)
     as = R[c  for c in coeffs(p)]
     as[1] += c

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -29,20 +29,21 @@ variable(p::P) where {P  <: StandardBasisPolynomial} = ⟒(P)([zero(p[0]), one(p
 function  basis(p::P, k::Int, _var::SymbolLike=:x; var=_var) where {P<:StandardBasisPolynomial}
     cs  = [zero(p[0]) for _ in 0:k]
     cs[end] = one(p[0])
-    P(cs, var)
+    ⟒(P)(cs, var)
 end
 
 function fromroots(P::Type{<:StandardBasisPolynomial}, r::AbstractVector{T}; var::SymbolLike = :x) where {T}
-    x = variable(⟒(P)([one(first(r))], var))
-    return prod(x - rᵢ for rᵢ in r)
     n = length(r)
+    iszero(n)  && return ⟒(P)([one(T)], var)
+    
+    
     c = zeros(T, n + 1)
     c[1] = one(T)
     for j in 1:n, i in j:-1:1
         c[(i + 1)] = c[(i + 1)] - r[j] * c[i]
     end
     #return P(c, var)
-    return P(reverse(c), var)
+    return ⟒(P)(reverse(c), var)
 end
 
 
@@ -87,7 +88,7 @@ function integrate(p::P, k::S=0*p[0]) where {T, P <: StandardBasisPolynomial{T},
         return ⟒(P)([NaN])
     end
     n = length(p)
-    a2 = [0*p[0] for  _ in 1:n+1] #Vector{R}(undef, n + 1)
+    a2 = [0*p[0]/1 for  _ in 1:n+1] #Vector{R}(undef, n + 1)
     a2[1] = k
     @inbounds for i in 1:n
         a2[i + 1] = p[i - 1] / i

--- a/src/show.jl
+++ b/src/show.jl
@@ -160,7 +160,7 @@ end
 ## print * or cdot, ...
 function printproductsign(io::IO, pj::T, j, mimetype) where {T}
     iszero(j) && return
-    (showone(T) ||  !isone(pj)) &&  print(io, showop(mimetype, "*"))
+    (showone(T) ||  !_isone(pj)) &&  print(io, showop(mimetype, "*"))
 end
 
 # show a single term
@@ -203,7 +203,7 @@ printcoefficient(io::IO, pj::Any, j, mimetype) = Base.show_unquoted(io, pj, 0, B
 
 # pretty print rational numbers in latex
 function printcoefficient(io::IO, a::Rational{T}, j, mimetype::MIME"text/latex") where {T}
-    isone(abs(a.den)) ? print(io, a.num) : print(io, "\\frac{$(a.num)}{$(a.den)}")
+    _isone(abs(a.den)) ? print(io, a.num) : print(io, "\\frac{$(a.num)}{$(a.den)}")
 end
 
 # print complex numbers with parentheses as needed
@@ -216,7 +216,7 @@ function printcoefficient(io::IO, pj::Complex{T}, j, mimetype) where {T}
         Base.show_unquoted(io, pj, 0, Base.operator_precedence(:*))
     elseif hasreal
         a = real(pj)
-        (iszero(j) || showone(T) || !isone(a)) && printcoefficient(io, a, j, mimetype)
+        (iszero(j) || showone(T) || !_isone(a)) && printcoefficient(io, a, j, mimetype)
     elseif hasimag
         b = imag(pj)
         (showone(T) || b != one(T)) && printcoefficient(io, b, j,  mimetype)


### PR DESCRIPTION
This is an attempt at relaxing  the  `T <: Number` baked into  the  `Polynomial{T}`   type,  in particular  allowing `T=AbstractArray{S,N}`. It gets only half  way there, and  it is not clear to  me how to  get the other half.  It  does allow  the usual  polynomial operations: addition,  subtraction,  multiplication (with  understandable limitations), ...

 The  big issue  is related to the fact that  a type such as `Polynomial{Matrix{T}}` or `Polynomial{Vector{T}}`  does not  carry  enough shape  information to  allow  for some useful concepts (e.g. `zeros(Matrix{T},n)` or `Vector{Matrix{T}}(undef, n)`. This WIP adds kludgy bypasses  for  these  when an instance is known, but there are areas where only the type is known. Primarily, these are in promotion, as illustrated in the cases  below.

Some success and failures can be gleaned  from  running  this:
```
using Polynomials,  Test,  SymbolicUtils
P =  Polynomial

vs = [1,2,3]
vv = [[1,2], [2,3],[3,4]]
vm = [[1 2;3 4], [2 3;4 5], [3 4; 5 6]]
@syms a0::Real a1::Real a2::Real  a::Real  # number  like but not <:Number
vsym = [a0, a1, a2]


p = P(vs)
q = P(vv)
r = P(vm)
#s = P(vsym) # iszero(a0) ∉  Bool

@test p  +  1 == 1 + p
@test q + [1,1] == [1,1] + q
@test r + [1 1;1 1] == [1 1; 1 1] + r
#@test s + a == a + s

@test p*3 == 3*p
@test q*2 == 2*q
@test r*2 == 2*r
#@test s*2 == 2*s

@test -p == 0 - p
@test -q == [0,0] - q
@test -r == [0 0; 0 0] - r
#@test -s == zero(s) - s

@test p + 2p == 3p
@test q + 2q == 3q
@test r + 2r == 3r
#@test s + 2s == 3s

@test p*p == p^2
@test_throws  MethodError q*q == r^2
@test r*r  == r^2
#@test s*s ==  s^2

@test isa(p(1),  eltype(p))
@test isa(q(1),  eltype(q))
@test isa(r(1),  eltype(r))
#@test isa(s(1), eltype(s))

@test zero(p) ==  0*p
@test zero(q) ==  0*q
@test zero(r) ==  0*r

@test one(p) ==  P(one(vs[1]))
@test_throws MethodError  one(q) #  no `one(vv[1])`
@test one(r) ==  P([one(vm[1])]) ## note [...]

@test  degree(variable(p)) == 1
@test_throws  MethodError  variable(q)   # no one(vv[1]), so what is 1x?
@test  degree(variable(r)) == 1

basis = Polynomials.basis
@test degree(basis(p,2)) == 2
@test_throws  MethodError basis(q,2)
@test degree(basis(r,2)) == 2


@test (derivative∘integrate)(p) == p
@test (derivative∘integrate)(q) == q
@test (derivative∘integrate)(r) == r

@test fromroots(P, vs[1:1]) == variable(p) - vs[1,1]
@test_throws MethodError fromroots(P, vv[1:1]) == variable(q) - vv[1,1] # no variable
@test fromroots(P, vm[1:1]) == variable(r) - vm[1,1]

## Promotion questions
Base.promote(p::Polynomial{T}, x::T) where {T} = (p, Polynomial([x])) # reasonable defn
@test promote(p, vs[1]) == (p, P(vs[1:1]))
@test promote(q, vv[1]) == (q, P(vv[1:1]))
@test promote(r, vm[1]) == (r, P(vm[1:1]))

#  change type (e.g., promote(p::Polynomial{T}, x::S))
vsf, vvf, vmf = float.(vs), float.(vv), float.(vm)
@test promote(p, vsf[1]) == (p, P(vsf[1:1]))
@test_throws MethodError promote(q, vvf[1]) == (q, P(vvf[1:1])) #  fails to promote
@test_throws MethodError promote(r, vmf[1]) == (r, P(vmf[1:1]))

## What  is  reasonable promotion  rule
# Base.promote(p::Polynomial{T}, x::S)  = ... # too generic!
# this one  works, but is too specific and not generic
function Base.promote(p::Polynomial{V}, x::W)  where {T,N,V<:AbstractArray{T,N}, S, W<: AbstractArray{S,N}} 
    R = promote_type(T,S)
    Polynomial([R.(c) for c  in coeffs(p)], p.var), Polynomial([R.(x)], p.var)
end
@test promote(q, vvf[1]) == (q, P(vvf[1:1])) 
@test promote(r, vmf[1]) == (r, P(vmf[1:1]))

# with  this  we have  still have issues with the  promotion machinery
[r, vmf[1]] # works
[r  vmf[1]] # fails            # _cat
[r^0 r; r^2 r^3] # works
[vmf[1] r; r^2 r^3] fails  #   calls down to  `typed_hvcat`



# other issues

# need instance, not type
@test_throws  MethodError zero(typeof(r), 2)
@test_throws  MethodError one(typeof(r), 2)
@test_throws  MethodError variable(typeof(r), 2)
@test_throws  MethodError basis(typeof(r), 2)

# could  work around this one presumably
@test_throws MethodError q ≈ q
@test_throws MethodError r ≈ r
```

