### PR TITLE
use conversion for P(n); closes #237

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -49,8 +49,8 @@ macro register(name)
         $poly{T}(x::AbstractVector{S}, var::SymbolLike = :x) where {T,S<:Number} =
             $poly(T.(x), Symbol(var))
         $poly{T}(n::S, var::SymbolLike = :x) where {T, S<:Number} =
-            $poly(T[n], Symbol(var))
-        $poly(n::Number, var::SymbolLike = :x) = $poly([n], Symbol(var))
+            n *  one($poly{T}, Symbol(var))
+        $poly(n::S, var::SymbolLike = :x)  where {S  <: Number} = n * one($poly{S}, Symbol(var))
         $poly{T}(var::SymbolLike=:x) where {T} = variable($poly{T}, Symbol(var))
         $poly(var::SymbolLike=:x) = variable($poly, Symbol(var))
     end

--- a/src/common.jl
+++ b/src/common.jl
@@ -430,7 +430,7 @@ Base.zero(p::P) where {P <: AbstractPolynomial} = zero(P, p.var)
 
 Returns a representation of 1 as the given polynomial.
 """
-Base.one(::Type{P}, var=:x) where {P <: AbstractPolynomial} = ⟒(P)(ones(eltype(P),1), var)
+Base.one(::Type{P}, var=:x) where {P <: AbstractPolynomial} = ⟒(P)(ones(eltype(P),1), var)  # assumes  p₀ = 1
 Base.one(p::P) where {P <: AbstractPolynomial} = one(P, p.var)
 
 Base.oneunit(::Type{P}, args...) where {P <: AbstractPolynomial} = one(P, args...)

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -39,10 +39,10 @@ Polynomials.@register Poly
 Base.convert(P::Type{<:Polynomial}, p::Poly{T}) where {T} = P(p.coeffs, p.var)
 
 Base.eltype(P::Type{<:Poly}) = P
-Base.zero(::Type{<:Poly{T}},var=:x)  where {T} = Poly{T}(zeros(T,0), var)
-Base.zero(::Type{<:Poly},var=:x)  where {T} = Poly(zeros(Float64,0), var)
-Base.one(::Type{<:Poly{T}},var=:x)  where {T} = Poly{T}(ones(T,1), var)
-Base.one(::Type{<:Poly},var=:x)  where {T} = Poly(ones(Float64,1), var)
+_eltype(::Type{<:Poly{T}}) where  {T} = T
+_eltype(::Type{Poly}) =  Float64
+Base.zero(P::Type{<:Poly},var=:x) = Poly(zeros(_eltype(P),0), var)
+Base.one(P::Type{<:Poly},var=:x) = Poly(ones(_eltype(P),1), var)
 function Polynomials.basis(P::Type{<:Poly}, k::Int, _var::Polynomials.SymbolLike=:x; var=_var) 
     zs = zeros(Int, k+1)
     zs[end] = 1

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -83,6 +83,10 @@ end
         @test iszero(p0)
         P != LaurentPolynomial && @test degree(p0) == -1
 
+        # P(2) is  2 (not  2p₀)  connvert(Polynomial, P(s::Number)) = Polynomial(s)
+        @test convert(Polynomial, P(2)) ≈ Polynomial(2)
+        @test P(2)  ≈ 2*one(P)
+        
         # variable(), P() to generate `x` in given basis
         @test degree(variable(P)) == 1
         @test variable(P)(1) == 1


### PR DESCRIPTION
Issue 237 is about `P(n)` being conversion and not a shorthand for `P([n])`. This is not an issue for standard basis polynomials, but is potentially for others. This addresses the problem by setting `P(n) = n*one(P)`.