### PR TITLE
Modified fromroots() so that it returns real coefficients if complex poles come in conjugate pairs.

### DIFF
--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -442,6 +442,10 @@ end
         x = variable()
         plarge = 8.362779449448982e41 - 2.510840694154672e57x + 4.2817430781178795e44x^2 - 1.6225927682921337e31x^3 + 1.0x^4  # #120
         @test length(roots(plarge)) == 4
+
+        a = P([1,1,1])*P([1,0.5,1])*P([1,1])    # two complex conjugate pole pairs and one real pole
+        r = roots(a)
+        @test (fromroots(r) ≈ a) & isreal(coeffs(a))    # the coeff should be real
     end
 end
 

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -443,9 +443,12 @@ end
         plarge = 8.362779449448982e41 - 2.510840694154672e57x + 4.2817430781178795e44x^2 - 1.6225927682921337e31x^3 + 1.0x^4  # #120
         @test length(roots(plarge)) == 4
 
-        a = P([1,1,1])*P([1,0.5,1])*P([1,1])    # two complex conjugate pole pairs and one real pole
-        r = roots(a)
-        @test (fromroots(r) ≈ a) & isreal(coeffs(a))    # the coeff should be real
+        @test begin
+            a = P([1,1,1])*P([1,0.5,1])*P([1,1])    # two complex conjugate pole pairs and one real pole
+            r = roots(a)
+            b = fromroots(r)
+            (b ≈ a) & isreal(coeffs(b))    # the coeff should be real
+        end
     end
 end
 


### PR DESCRIPTION
I added just one (long) line to the code for `fromroots()` so that it returns real coefficients if complex poles come in conjugate pairs. The code just checks if the complex poles with a positive imaginary part are equal to the complex-conjugated poles with a negative imaginary part, and if yes, it sets the imaginary part of the already computed coefficients to zero.  Example:

```julia
julia> a = Polynomial([1,1,1])*Polynomial([1,0.5,1])*Polynomial([1,1])
Polynomial(1.0 + 2.5*x + 4.0*x^2 + 4.0*x^3 + 2.5*x^4 + 1.0*x^5)

julia> r = roots(a)
5-element Array{Complex{Float64},1}:
  -0.9999999999999991 + 0.0im
  -0.5000000000000009 - 0.866025403784436im
  -0.5000000000000009 + 0.866025403784436im
 -0.25000000000000033 - 0.9682458365518557im
 -0.25000000000000033 + 0.9682458365518557im

julia> fromroots(r)
Polynomial(0.9999999999999984 + 2.5000000000000018*x + 4.000000000000003*x^2 + 4.000000000000002*x^3 + 2.5000000000000018*x^4 + 1.0*x^5)
```