### PR TITLE
use m (not m:n) to specify polynomial; close issue #254

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "1.1.5"
+version = "1.1.6"
 
 [deps]
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -5,7 +5,7 @@ export LaurentPolynomial
 
 A [Laurent](https://en.wikipedia.org/wiki/Laurent_polynomial) polynomial is of the form `a_{m}x^m + ... + a_{n}x^n` where `m,n` are  integers (not necessarily positive) with ` m <= n`.
 
-The `coeffs` specify `a_{m}, a_{m-1}, ..., a_{n}`. The range specified is of the  form  `m:n`,  if left  empty, `0:length(coeffs)-1` is  used (i.e.,  the coefficients refer  to the standard basis). Alternatively, the coefficients can be specified using an `OffsetVector` from the `OffsetArrays` package.
+The `coeffs` specify `a_{m}, a_{m-1}, ..., a_{n}`. The range specified is of the  form  `m` (or `m:n`),  if left  empty, `m` is taken to be `0` (i.e.,  the coefficients refer  to the standard basis). Alternatively, the coefficients can be specified using an `OffsetVector` from the `OffsetArrays` package.
 
 Laurent polynomials and standard basis polynomials  promote to  Laurent polynomials. Laurent polynomials may be  converted to a standard basis  polynomial when `m >= 0`
 .
@@ -19,7 +19,7 @@ julia> using Polynomials
 julia> P = LaurentPolynomial
 LaurentPolynomial
 
-julia> p = P([1,1,1],  -1:1)
+julia> p = P([1,1,1],  -1)
 LaurentPolynomial(x⁻¹ + 1 + x)
 
 julia> q = P([1,1,1])
@@ -49,7 +49,7 @@ LaurentPolynomial(1.0*x + 0.5*x² + 0.3333333333333333*x³)
 julia> integrate(p)  # x⁻¹  term is an issue
 ERROR: ArgumentError: Can't integrate Laurent  polynomial with  `x⁻¹` term
 
-julia> integrate(P([1,1,1], -5:-3))
+julia> integrate(P([1,1,1], -5))
 LaurentPolynomial(-0.25*x⁻⁴ - 0.3333333333333333*x⁻³ - 0.5*x⁻²)
 
 julia> x⁻¹ = inv(variable(LaurentPolynomial)) # `inv` defined on monomials
@@ -71,20 +71,18 @@ struct LaurentPolynomial{T <: Number} <: StandardBasisPolynomial{T}
     m::Base.RefValue{Int64}
     n::Base.RefValue{Int64}
     function LaurentPolynomial{T}(coeffs::AbstractVector{T},
-                                  rng::UnitRange{Int64}=0:length(coeffs)-1,
+                                  m::Int,
                                   var::Symbol=:x) where {T <: Number}
 
-        m,n = first(rng), last(rng)
-
+        
         # trim zeros from front and back
         lnz = findlast(!iszero, coeffs)
         fnz = findfirst(!iszero, coeffs)
         (lnz == nothing || length(coeffs) == 0) && return new{T}(zeros(T,1), var, Ref(0), Ref(0))
-        if  lnz !=  length(rng) ||  fnz !=  1
-            coeffs =  coeffs[fnz:lnz]
-            m = m + fnz - 1
-            n = m + (lnz-fnz)
-        end
+        coeffs =  coeffs[fnz:lnz]
+        m = m + fnz - 1
+        n = m + (lnz-fnz)
+
         (n-m+1  == length(coeffs)) || throw(ArgumentError("Lengths do not match"))
 
         new{T}(coeffs, var, Ref(m),  Ref(n))
@@ -93,6 +91,27 @@ struct LaurentPolynomial{T <: Number} <: StandardBasisPolynomial{T}
 end
 
 @register LaurentPolynomial
+
+## constructors
+function LaurentPolynomial{T}(coeffs::AbstractVector{S}, m::Int, var::Symbol=:x) where {
+    T <: Number, S <: Number}
+    LaurentPolynomial{T}(T.(coeffs), m, var)
+end
+
+function LaurentPolynomial{T}(coeffs::AbstractVector{S}, var::Symbol=:x) where {
+    T <: Number, S <: Number}
+    LaurentPolynomial{T}(T.(coeffs), 0, var)
+end
+    
+function LaurentPolynomial(coeffs::AbstractVector{T}, m::Int, var::SymbolLike=:x) where {T <: Number}
+    LaurentPolynomial{T}(coeffs, m, Symbol(var))
+end
+
+function LaurentPolynomial(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {T <: Number}
+    LaurentPolynomial{T}(coeffs, 0, Symbol(var))
+end
+
+
 
 # Add interface for OffsetArray
 function  LaurentPolynomial{T}(coeffs::OffsetArray{S, 1, Array{S,1}}, var::SymbolLike=:x) where {T, S}
@@ -104,22 +123,19 @@ function  LaurentPolynomial(coeffs::OffsetArray{S, 1, Array{S,1}}, var::SymbolLi
 end
 
 
-
+## Alternate with range specified
 function  LaurentPolynomial{T}(coeffs::AbstractVector{S},
-                               rng::UnitRange{Int64}=0:length(coeffs)-1,
+                               rng::UnitRange{Int64},
                                var::Symbol=:x) where {T <: Number, S <: Number}
-    LaurentPolynomial{T}(T.(coeffs), rng, var)
+    LaurentPolynomial{T}(T.(coeffs), first(rng), var)
 end
 
 function LaurentPolynomial(coeffs::AbstractVector{T}, rng::UnitRange, var::SymbolLike=:x) where {T <: Number}
     LaurentPolynomial{T}(coeffs, rng, Symbol(var))
 end
 
-function LaurentPolynomial(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {T <: Number}
-    LaurentPolynomial{T}(coeffs, 0:length(coeffs)-1, Symbol(var))
-end
 
-## Alternate interface
+## Alternate interface for Polynomial
 Polynomial(coeffs::OffsetArray{T,1,Array{T,1}}, var::SymbolLike=:x) where {T <: Number} =
     LaurentPolynomial{T}(coeffs, var)
 
@@ -138,37 +154,44 @@ Base.promote_rule(::Type{Q},::Type{P}) where {T, P <: LaurentPolynomial{T}, S, Q
     LaurentPolynomial{promote_type(T, S)}
 
 function Base.convert(P::Type{<:Polynomial}, q::LaurentPolynomial)
-    m,n = extrema(q)
+    m,n = (extrema∘degreerange)(q)
     m < 0 && throw(ArgumentError("Can't convert a Laurent polynomial with m < 0"))
     P([q[i] for i  in 0:n], q.var)
 end
 
 function Base.convert(::Type{P}, q::StandardBasisPolynomial{S}) where {T, P <:LaurentPolynomial{T},S}
     d = degree(q)
-    P([q[i] for i in 0:d], 0:degree(q), q.var)
+    P([q[i] for i in 0:d], 0, q.var)
 end
 
 ##
 ## generic functions
 ##
-Base.extrema(p::LaurentPolynomial) =  (p.m[],p.n[])
-Base.range(p::LaurentPolynomial) = p.m[]:p.n[]
+function Base.extrema(p::LaurentPolynomial)
+    Base.depwarn("`extrema(::LaurentPolynomial)` is deprecated. Use `(firstindex(p), lastindex(p))`", :extrema)
+    (p.m[], p.n[])
+end
+function Base.range(p::LaurentPolynomial)
+    Base.depwarn("`range(::LaurentPolynomial)` is deprecated. Use `firstindex(p):lastindex(p)`", :range)
+    p.m[]:p.n[]
+end
+
 function Base.inv(p::LaurentPolynomial)
-    m,n =  extrema(p)
+    m,n =  degreerange(p)
     m != n && throw(ArgumentError("Only monomials can be inverted"))
-    LaurentPolynomial([1/p for p in p.coeffs], -m:-n, p.var)
+    LaurentPolynomial([1/p for p in p.coeffs], -m, p.var)
 end
 
 ##
 ## changes to common.jl mostly as the range in the type is different
 ##
-Base.copy(p::P) where {P <: LaurentPolynomial} = P(copy(coeffs(p)), range(p), p.var)
+Base.copy(p::P) where {P <: LaurentPolynomial} = P(copy(coeffs(p)), degreerange(p), p.var)
 Base.:(==)(p1::LaurentPolynomial, p2::LaurentPolynomial) =
-    check_same_variable(p1, p2) && (range(p1) == range(p2)) && (coeffs(p1) == coeffs(p2))
-Base.hash(p::LaurentPolynomial, h::UInt) = hash(p.var, hash(range(p), hash(coeffs(p), h)))
+    check_same_variable(p1, p2) && (degreerange(p1) == degreerange(p2)) && (coeffs(p1) == coeffs(p2))
+Base.hash(p::LaurentPolynomial, h::UInt) = hash(p.var, hash(degreerange(p), hash(coeffs(p), h)))
 
 degree(p::LaurentPolynomial) = p.n[]
-isconstant(p::LaurentPolynomial) = range(p) == 0:0
+isconstant(p::LaurentPolynomial) = degreerange(p) == 0:0
 basis(P::Type{<:LaurentPolynomial{T}}, n::Int, var::SymbolLike=:x) where{T} = LaurentPolynomial(ones(T,1), n:n, var)
 basis(P::Type{LaurentPolynomial}, n::Int, var::SymbolLike=:x) = LaurentPolynomial(ones(Float64, 1), n:n, var)
 
@@ -179,7 +202,7 @@ Base.zero(p::P, var=Symbollike=:x) where {P  <: LaurentPolynomial} = zero(P, var
 
 # get/set index. Work with  offset
 function Base.getindex(p::LaurentPolynomial{T}, idx::Int) where {T <: Number}
-    m,n = extrema(p)
+    m,n = (extrema ∘ degreerange)(p)
     i = idx - m + 1
     (i < 1 || i > (n-m+1))  && return zero(T)
     p.coeffs[i]
@@ -188,7 +211,7 @@ end
 # extend if out of bounds
 function Base.setindex!(p::LaurentPolynomial{T}, value::Number, idx::Int) where {T}
 
-    m,n = extrema(p)
+    m,n = (extrema ∘ degreerange)(p)
     if idx > n
         append!(p.coeffs, zeros(T, idx-n))
         n = idx
@@ -208,7 +231,8 @@ end
 
 Base.firstindex(p::LaurentPolynomial) = p.m[]
 Base.lastindex(p::LaurentPolynomial) = p.n[]
-Base.eachindex(p::LaurentPolynomial) = range(p)
+Base.eachindex(p::LaurentPolynomial) = degreerange(p)
+degreerange(p::LaurentPolynomial) = firstindex(p):lastindex(p)
 
 ## chop/truncation
 # trim  from *both* ends
@@ -216,7 +240,7 @@ function chop!(p::P;
                rtol::Real = Base.rtoldefault(real(T)),
                atol::Real = 0,) where {T, P <: LaurentPolynomial{T}}
 
-    m0,n0 = m,n = extrema(p)
+    m0,n0 = m,n = (extrema ∘ degreerange)(p)
     for k in n:-1:m
         if isapprox(p[k], zero(T); rtol = rtol, atol = atol)
             n -= 1
@@ -304,8 +328,8 @@ true
 """
 function LinearAlgebra.conj(p::P) where {P <: LaurentPolynomial}
     ps = coeffs(p)
-    m,n = extrema(p)
-    ⟒(P)(conj(ps),m:n, p.var)
+    m = firstindex(p)
+    ⟒(P)(conj(ps), m, p.var)
 end
 
 
@@ -341,8 +365,8 @@ true
 function paraconj(p::LaurentPolynomial)
     cs = p.coeffs
     ds = adjoint.(cs)
-    m,n = extrema(p)
-    LaurentPolynomial(reverse(ds), -n:-m, p.var)
+    n = degree(p)
+    LaurentPolynomial(reverse(ds), -n, p.var)
 end
 
 """
@@ -383,13 +407,13 @@ true
 """
 function cconj(p::LaurentPolynomial)
     ps = conj.(coeffs(p))
-    m,n = extrema(p)
+    m,n = (extrema ∘ degreerange)(p)
     for i in m:n
         if isodd(i)
             ps[i+1-m] *= -1
         end
     end
-    LaurentPolynomial(ps, m:n, p.var)
+    LaurentPolynomial(ps, m, p.var)
 end
 
 
@@ -401,7 +425,7 @@ end
 
 # evaluation uses `evalpoly`
 function (p::LaurentPolynomial{T})(x::S) where {T,S}
-    m,n = extrema(p)
+    m,n = (extrema ∘ degreerange)(p)
     m  == n == 0 && return p[0] * _one(S)
     if m >= 0
         evalpoly(x, NTuple{n+1,T}(p[i] for i in 0:n))
@@ -419,22 +443,22 @@ end
 
 
 # scalar operattoinis
-Base.:-(p::P) where {P <: LaurentPolynomial} = P(-coeffs(p), range(p), p.var)
+Base.:-(p::P) where {P <: LaurentPolynomial} = P(-coeffs(p), firstindex(p), p.var)
 
 function Base.:+(p::LaurentPolynomial{T}, c::S) where {T, S <: Number}
-    q = LaurentPolynomial([c], 0:0, p.var)
+    q = LaurentPolynomial([c], 0, p.var)
     p + q
 end
 
 function Base.:*(p::P, c::S) where {T,P <: LaurentPolynomial,  S <: Number}
     as = c * copy(coeffs(p))
-    return ⟒(P)(as, range(p), p.var)
+    return ⟒(P)(as, firstindex(p), p.var)
 end
 
 
 function Base.:/(p::P, c::S) where {T,P <: LaurentPolynomial{T},S <: Number}
     R = promote_type(P, eltype(one(T) / one(S)))
-    return R(coeffs(p) ./ c, range(p), p.var)
+    return R(coeffs(p) ./ c, firstindex(p), p.var)
 end
 
 ##
@@ -443,17 +467,17 @@ end
 function Base.:+(p1::P1, p2::P2) where {T,P1<:LaurentPolynomial{T}, S, P2<:LaurentPolynomial{S}}
 
     if isconstant(p1)
-        p1 = P1(p1.coeffs, range(p1), p2.var)
+        p1 = P1(p1.coeffs, firstindex(p1), p2.var)
     elseif isconstant(p2)
-        p2 = P2(p2.coeffs, range(p2), p1.var)
+        p2 = P2(p2.coeffs, firstindex(p2), p1.var)
     end
 
     p1.var != p2.var && error("LaurentPolynomials must have same variable")
 
     R = promote_type(T,S)
 
-    m1,n1 = extrema(p1)
-    m2,n2 = extrema(p2)
+    m1,n1 = (extrema ∘ degreerange)(p1)
+    m2,n2 = (extrema ∘ degreerange)(p2)
     m,n = min(m1,m2), max(n1, n2)
 
     as = zeros(R, length(m:n))
@@ -461,7 +485,7 @@ function Base.:+(p1::P1, p2::P2) where {T,P1<:LaurentPolynomial{T}, S, P2<:Laure
         as[1 + i-m] = p1[i] + p2[i]
     end
 
-    q = LaurentPolynomial{R}(as, m:n, p1.var)
+    q = LaurentPolynomial{R}(as, m, p1.var)
     chop!(q)
 
     return q
@@ -477,8 +501,8 @@ function Base.:*(p1::LaurentPolynomial{T}, p2::LaurentPolynomial{S}) where {T,S}
 
     R = promote_type(T,S)
 
-    m1,n1 = extrema(p1)
-    m2,n2 = extrema(p2)
+    m1,n1 = (extrema ∘ degreerange)(p1)
+    m2,n2 = (extrema ∘ degreerange)(p2)
     m,n = m1 + m2, n1+n2
 
     as = zeros(R, length(m:n))
@@ -489,7 +513,7 @@ function Base.:*(p1::LaurentPolynomial{T}, p2::LaurentPolynomial{S}) where {T,S}
         end
     end
 
-    p = LaurentPolynomial(as, m:n, p1.var)
+    p = LaurentPolynomial(as, m, p1.var)
     chop!(p)
 
     return p
@@ -521,11 +545,13 @@ julia> roots(a)
 """
 function  roots(p::P; kwargs...)  where  {T, P <: LaurentPolynomial{T}}
     c = coeffs(p)
-    r = range(p)
-    d = r[end]-min(0,r[1])+1    # Length of the coefficient vector, taking into consideration the case when the lower degree is strictly positive (like p=3z^2).
-    z = zeros(T,d)                # Reserves space for the coefficient vector.
-    z[max(0,r[1])+1:end] = c    # Leaves the coeffs of the lower powers as zeros.
-    a = Polynomial(z,p.var)     # The root is then the root of the numerator polynomial.
+    r = degreerange(p)
+    d = r[end] - min(0, r[1]) + 1    # Length of the coefficient vector, taking into consideration
+                                     # the case when the lower degree is strictly positive
+                                     # (like p=3z^2).
+    z = zeros(T, d)                  # Reserves space for the coefficient vector.
+    z[max(0, r[1]) + 1:end] = c      # Leaves the coeffs of the lower powers as zeros.
+    a = Polynomial(z, p.var)         # The root is then the root of the numerator polynomial.
     return roots(a; kwargs...)
 end
 
@@ -539,7 +565,7 @@ function derivative(p::P, order::Integer = 1) where {T, P<:LaurentPolynomial{T}}
 
     hasnan(p) && return ⟒(P)(T[NaN], 0:0, p.var)
 
-    m,n = extrema(p)
+    m,n = (extrema ∘ degreerange)(p)
     m = m - order
     n = n - order
     as =  zeros(T, length(m:n))
@@ -553,7 +579,7 @@ function derivative(p::P, order::Integer = 1) where {T, P<:LaurentPolynomial{T}}
         end
     end
 
-    chop!(LaurentPolynomial(as, m:n, p.var))
+    chop!(LaurentPolynomial(as, m, p.var))
 
 end
 
@@ -564,11 +590,11 @@ function integrate(p::P, k::S) where {T, P<: LaurentPolynomial{T}, S<:Number}
     R = eltype((one(T)+one(S))/1)
 
     if hasnan(p) || isnan(k)
-        return P([NaN], 0:0, p.var) # not R(NaN)!! don't like XXX
+        return P([NaN], 0, p.var) # not R(NaN)!! don't like XXX
     end
 
 
-    m,n = extrema(p)
+    m,n = (extrema ∘ degreerange)(p)
     if  n < 0
         n = 0
     else
@@ -587,14 +613,14 @@ function integrate(p::P, k::S) where {T, P<: LaurentPolynomial{T}, S<:Number}
 
     as[1-m] = k
 
-    return ⟒(P)(as, m:n, p.var)
+    return ⟒(P)(as, m, p.var)
 
 end
 
 
 function Base.gcd(p::LaurentPolynomial{T}, q::LaurentPolynomial{T}, args...; kwargs...) where {T}
-    mp, Mp = extrema(p)
-    mq, Mq = extrema(q)
+    mp, Mp = (extrema ∘ degreerange)(p)
+    mq, Mq = (extrema ∘ degreerange)(q)
     if mp < 0 || mq < 0
         throw(ArgumentError("GCD is not defined when there are `x⁻¹` terms"))
     end

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -431,7 +431,7 @@ end
         @test roots(pNULL) == []
         @test sort(roots(pR)) == [1 // 2, 3 // 2]
 
-        @test sort(roots(LaurentPolynomial([24,10,-15,0,1],-2:1,:z)))≈[-4.0,-1.0,2.0,3.0]
+        @test sort(roots(LaurentPolynomial([24,10,-15,0,1],-2,:z)))≈[-4.0,-1.0,2.0,3.0]
 
         A = [1 0; 0 1]
         @test fromroots(A) == Polynomial(Float64[1, -2, 1])


### PR DESCRIPTION
* Allow just `m` in specifying a polynomial (not `m:n`)
* deprecate use of `extrema(p)` to return `(firstindex(p), lastindex(p))`
* deprecate use of `range(p)` to return `firstindex(p):lastindex(p)`. Add non-exported `degreerange` for this.

Consider this as non-breaking, as neither `extrema` or `range` were documented.