### PR TITLE
add compensated_horner method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "1.1.6"
+version = "1.1.7"
 
 [deps]
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -308,7 +308,7 @@ Evaluate `p(x)` using a compensation scheme of S. Graillat, Ph. Langlois, N. Lou
 
 The Horner scheme has relative error given by
 
-`|(p(x) - p̂(x))/p(x)| ≤ α ⋅ u ⋅ cond(p, x)`, where `u` is the precision (`2⁻⁵³`).
+`|(p(x) - p̂(x))/p(x)| ≤ α(n) ⋅ u ⋅ cond(p, x)`, where `u` is the precision (`2⁻⁵³ = eps()/2`)).
 
 The compensated Horner scheme has relative error bounded by
 

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -384,9 +384,12 @@ end
         p = f(x)
         e₁ = abs( (f(4/3) - p(4/3))/ p(4/3) )
         e₂ = abs( (f(4/3) - Polynomials.compensated_horner(p, 4/3))/ p(4/3) )
-        @test cond(p, 4/3) > 1/eps()
-        @test e₁ > sqrt(eps())
-        @test e₂ <= 4eps()        
+        λ = cond(p, 4/3)
+        u = eps()/2
+        @test λ > 1/u
+        @test e₁ <= 2 * 20 * u * λ
+        @test e₁ > u^(1/4)
+        @test e₂ <= u + u^2 * λ * 100
     end
 end
 

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -342,8 +342,10 @@ end
         # issue #209
         ps  = [P([0,1]), P([0,0,1])]
         @test Polynomials.evalpoly.(1/2, ps) ≈ [p(1/2)  for  p  in ps]
+
     end
 
+    
     # constant polynomials and type
     Ts = (Int, Float32, Float64, Complex{Int}, Complex{Float64})
     for P in (Polynomial, ImmutablePolynomial, SparsePolynomial)
@@ -374,7 +376,18 @@ end
         @test eltype(p3) == eltype(p2)
     end
 
-
+    # compensated_horner
+    # polynomial evaluation for polynomials with large condition numbers
+    for P in (Polynomial, ImmutablePolynomial, SparsePolynomial)
+        x = variable(P{Float64})
+        f(x) = (x - 1)^20
+        p = f(x)
+        e₁ = abs( (f(4/3) - p(4/3))/ p(4/3) )
+        e₂ = abs( (f(4/3) - Polynomials.compensated_horner(p, 4/3))/ p(4/3) )
+        @test cond(p, 4/3) > 1/eps()
+        @test e₁ > sqrt(eps())
+        @test e₂ <= 4eps()        
+    end
 end
 
 @testset "Conversion" begin


### PR DESCRIPTION
Following a conversation at https://discourse.julialang.org/t/more-accurate-evalpoly/45932/5 it seemed that there might be a use for more accurate polynomial evaluation for poorly conditioned polynomials. This follows Graillat et.al [Compensated Horner Scheme](https://cadxfem.org/cao/Compensation-horner.pdf) to provide a `compensated_horner` method.