### PR TITLE
WIP: close #261

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,3 @@ after_success:
         Pkg.add("Coverage")
         using Coverage
         Codecov.submit(process_folder())'
-        

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -26,7 +26,7 @@ ChebyshevT(1.0⋅T_0(x))
 struct ChebyshevT{T <: Number} <: AbstractPolynomial{T}
     coeffs::Vector{T}
     var::Symbol
-    function ChebyshevT{T}(coeffs::AbstractVector{T}, var::Symbol) where {T <: Number}
+    function ChebyshevT{T}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {T <: Number}
         length(coeffs) == 0 && return new{T}(zeros(T, 1), var)
         last_nz = findlast(!iszero, coeffs)
         last = max(1, last_nz === nothing ? 0 : last_nz)
@@ -35,6 +35,13 @@ struct ChebyshevT{T <: Number} <: AbstractPolynomial{T}
 end
 
 @register ChebyshevT
+
+function ChebyshevT{T}(coeffs::OffsetArray{T,1, Array{T, 1}}, var::SymbolLike=:x) where {T <: Number}
+    cs = zeros(T, 1 + lastindex(coeffs))
+    cs[1 .+ (firstindex(coeffs):lastindex(coeffs))] = coeffs.parent
+    ChebyshevT{T}(cs, var)
+end
+
 
 function Base.convert(P::Type{<:Polynomial}, ch::ChebyshevT)
     if length(ch) < 3
@@ -57,6 +64,7 @@ function Base.convert(C::Type{<:ChebyshevT}, p::Polynomial)
     end
     return res
 end
+
 
 domain(::Type{<:ChebyshevT}) = Interval(-1, 1)
 variable(P::Type{<:ChebyshevT}, var::SymbolLike=:x ) = P([0,1], var)

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -83,12 +83,14 @@ end
 
 # entry point from abstract.jl; note T <: Number
 function ImmutablePolynomial{T}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {T <: Number}
+    M = length(coeffs)
+    ImmutablePolynomial{T}(NTuple{M,T}(tuple(coeffs...)), var)
+end
+
+function ImmutablePolynomial{T}(coeffs::OffsetArray{T,1, Array{T, 1}}, var::SymbolLike=:x) where {T <: Number}
     cs = zeros(T, 1 + lastindex(coeffs))
-    for i in eachindex(coeffs)
-        cs[1+i] = coeffs[i]
-    end
-    M = length(cs)
-    ImmutablePolynomial{T}(NTuple{M,T}(tuple(cs...)), var)
+    cs[1 .+ (firstindex(coeffs):lastindex(coeffs))] = coeffs.parent
+    ImmutablePolynomial{T}(cs, var)
 end
 
 ## --

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -83,9 +83,9 @@ end
 
 # entry point from abstract.jl; note T <: Number
 function ImmutablePolynomial{T}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {T <: Number}
-    cs = zeros(T, lastindex(coeffs))
+    cs = zeros(T, 1 + lastindex(coeffs))
     for i in eachindex(coeffs)
-        cs[i] = coeffs[i]
+        cs[1+i] = coeffs[i]
     end
     M = length(cs)
     ImmutablePolynomial{T}(NTuple{M,T}(tuple(cs...)), var)

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -81,10 +81,14 @@ function ImmutablePolynomial{T}(coeffs::Tuple, var::SymbolLike=:x)  where {T}
     ImmutablePolynomial{T}(T.(coeffs), var)
 end
 
-# entry point from abstract.jl; note Vector -- not AbstractVector -- type
-function ImmutablePolynomial{T}(coeffs::Vector{T}, var::SymbolLike=:x) where {T}
-    M = length(coeffs)
-    ImmutablePolynomial{T}(NTuple{M,T}(tuple(coeffs...)), var)
+# entry point from abstract.jl; note T <: Number
+function ImmutablePolynomial{T}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {T <: Number}
+    cs = zeros(T, lastindex(coeffs))
+    for i in eachindex(coeffs)
+        cs[i] = coeffs[i]
+    end
+    M = length(cs)
+    ImmutablePolynomial{T}(NTuple{M,T}(tuple(cs...)), var)
 end
 
 ## --

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -101,21 +101,17 @@ function ImmutablePolynomial(coeffs::Tuple, var::SymbolLike=:x)
     ImmutablePolynomial{T}(cs, var)
 end
 
-# # need to catch map case wihch return Variables, not Values
-# function ImmutablePolynomial(coeffs::Cs, var::SymbolLike=:x) where {
-#     M, T, Cs <: Union{Values{M,T}, Variables{M,T}}}
-#     ImmutablePolynomial{T}(Values(coeffs.v), var)
-# end
-
-
-
-
 # Convenience; pass tuple to Polynomial
 # Not documented, not sure this is a good idea as P(...)::P is not true...
-Polynomial(coeffs::NTuple{N,T}, var::SymbolLike = :x) where{N,T} =
+# Deprecated
+function Polynomial(coeffs::NTuple{N,T}, var::SymbolLike = :x) where{N,T}
+    Base.depwarn("Use of `Polynomial(NTuple, var)` is deprecated. Use the `ImmutablePolynomial` constructor",
+                 :Polynomial)
     ImmutablePolynomial(coeffs, var)
-
+end
 function Polynomial{T}(coeffs::NTuple{N,S}, var::SymbolLike = :x) where{N,T,S}
+    Base.depwarn("Use of `Polynomial(NTuple, var)` is deprecated. Use the `ImmutablePolynomial` constructor",
+                 :Polynomial)
     ImmutablePolynomial{N,T}(T.(coeffs), var)
 end
 
@@ -214,7 +210,6 @@ function Base.:+(p1::ImmutablePolynomial{T,N}, p2::ImmutablePolynomial{S,M}) whe
 
     p1.var != p2.var && error("Polynomials must have same variable")
 
-
     if  N == M
         cs = NTuple{N,R}(p1[i] + p2[i] for i in 0:N-1)
         ImmutablePolynomial{R}(cs, p1.var)        
@@ -225,8 +220,6 @@ function Base.:+(p1::ImmutablePolynomial{T,N}, p2::ImmutablePolynomial{S,M}) whe
         cs = (p1.coeffs) ⊕ (p2.coeffs)
         ImmutablePolynomial{R,N}(cs, p1.var)                
     end
-
-    
 
 end
 
@@ -297,9 +290,6 @@ function Base.:+(p::ImmutablePolynomial{T,N}, c::S) where {T, N, S<:Number}
     N == 0 && return ImmutablePolynomial{R,1}((c,), p.var)
     N == 1 && return ImmutablePolynomial((p[0]+c,), p.var)
 
-#    cs = NTuple{N,R}(iszero(i) ? p[i]+c : p[i] for i in 0:N-1)
-#    return ImmutablePolynomial{R,N}(cs, p.var)
-    
     q = ImmutablePolynomial{R,1}((c,), p.var)
     return p + q
 

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -136,12 +136,6 @@ function LaurentPolynomial(coeffs::AbstractVector{T}, rng::UnitRange, var::Symbo
 end
 
 
-## Alternate interface for Polynomial
-Polynomial(coeffs::OffsetArray{T,1,Array{T,1}}, var::SymbolLike=:x) where {T <: Number} =
-    LaurentPolynomial{T}(coeffs, var)
-
-Polynomial{T}(coeffs::OffsetArray{S,1,Array{S,1}}, var::SymbolLike=:x) where {T <: Number, S <: Number} =
-    LaurentPolynomial{T}(coeffs, var)
 
 ##
 ## conversion

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -5,7 +5,7 @@ export LaurentPolynomial
 
 A [Laurent](https://en.wikipedia.org/wiki/Laurent_polynomial) polynomial is of the form `a_{m}x^m + ... + a_{n}x^n` where `m,n` are  integers (not necessarily positive) with ` m <= n`.
 
-The `coeffs` specify `a_{m}, a_{m-1}, ..., a_{n}`. The range specified is of the  form  `m` (or `m:n`),  if left  empty, `m` is taken to be `0` (i.e.,  the coefficients refer  to the standard basis). Alternatively, the coefficients can be specified using an `OffsetVector` from the `OffsetArrays` package.
+The `coeffs` specify `a_{m}, a_{m-1}, ..., a_{n}`. The range specified is of the  form  `m`,  if left  empty, `m` is taken to be `0` (i.e.,  the coefficients refer  to the standard basis). Alternatively, the coefficients can be specified using an `OffsetVector` from the `OffsetArrays` package.
 
 Laurent polynomials and standard basis polynomials  promote to  Laurent polynomials. Laurent polynomials may be  converted to a standard basis  polynomial when `m >= 0`
 .
@@ -98,40 +98,38 @@ function LaurentPolynomial{T}(coeffs::AbstractVector{S}, m::Int, var::SymbolLike
     LaurentPolynomial{T}(T.(coeffs), m, var)
 end
 
-function LaurentPolynomial{T}(coeffs::AbstractVector{S}, var::SymbolLike=:x) where {
-    T <: Number, S <: Number}
-    LaurentPolynomial{T}(T.(coeffs), 0, var)
+function LaurentPolynomial{T}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {
+    T <: Number}
+    LaurentPolynomial{T}(coeffs, 0, var)
 end
-    
+
+function  LaurentPolynomial{T}(coeffs::OffsetArray{T, 1, Array{T,1}}, var::SymbolLike=:x) where {
+    T<:Number}
+    m,n = axes(coeffs, 1)
+    LaurentPolynomial{T}(T.(coeffs.parent), m, Symbol(var))
+end
+
 function LaurentPolynomial(coeffs::AbstractVector{T}, m::Int, var::SymbolLike=:x) where {T <: Number}
     LaurentPolynomial{T}(coeffs, m, Symbol(var))
 end
 
-function LaurentPolynomial(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {T <: Number}
-    LaurentPolynomial{T}(coeffs, 0, Symbol(var))
-end
 
-
-
-# Add interface for OffsetArray
-function  LaurentPolynomial{T}(coeffs::OffsetArray{S, 1, Array{S,1}}, var::SymbolLike=:x) where {
-    T<:Number, S<:Number}
-    m,n = axes(coeffs, 1)
-    LaurentPolynomial{T}(T.(coeffs.parent), m:n, Symbol(var))
-end
-function  LaurentPolynomial(coeffs::OffsetArray{S, 1, Array{S,1}}, var::SymbolLike=:x) where {S}
-    LaurentPolynomial{S}(coeffs, var)
-end
 
 
 ## Alternate with range specified
+## Deprecate
 function  LaurentPolynomial{T}(coeffs::AbstractVector{S},
                                rng::UnitRange{Int64},
                                var::Symbol=:x) where {T <: Number, S <: Number}
+    Base.depwarn("Using a range to indicate the offset is deprecated. Use just the lower value",
+                 :LaurentPolynomial)
+    error("")
     LaurentPolynomial{T}(T.(coeffs), first(rng), var)
 end
 
 function LaurentPolynomial(coeffs::AbstractVector{T}, rng::UnitRange, var::SymbolLike=:x) where {T <: Number}
+    Base.depwarn("Using a range to indicate the offset is deprecated. Use just the lower value",
+                 :LaurentPolynomial)
     LaurentPolynomial{T}(coeffs, rng, Symbol(var))
 end
 
@@ -185,10 +183,10 @@ Base.:(==)(p1::LaurentPolynomial, p2::LaurentPolynomial) =
 Base.hash(p::LaurentPolynomial, h::UInt) = hash(p.var, hash(degreerange(p), hash(coeffs(p), h)))
 
 isconstant(p::LaurentPolynomial) = iszero(lastindex(p)) && iszero(firstindex(p)) 
-basis(P::Type{<:LaurentPolynomial{T}}, n::Int, var::SymbolLike=:x) where{T} = LaurentPolynomial(ones(T,1), n:n, var)
-basis(P::Type{LaurentPolynomial}, n::Int, var::SymbolLike=:x) = LaurentPolynomial(ones(Float64, 1), n:n, var)
+basis(P::Type{<:LaurentPolynomial{T}}, n::Int, var::SymbolLike=:x) where{T} = LaurentPolynomial(ones(T,1), n, var)
+basis(P::Type{LaurentPolynomial}, n::Int, var::SymbolLike=:x) = LaurentPolynomial(ones(Float64, 1), n, var)
 
-Base.zero(::Type{LaurentPolynomial{T}},  var=Symbollike=:x) where {T} =  LaurentPolynomial{T}(zeros(T,1),  0:0, Symbol(var))
+Base.zero(::Type{LaurentPolynomial{T}},  var=Symbollike=:x) where {T} =  LaurentPolynomial{T}(zeros(T,1),  0, Symbol(var))
 Base.zero(::Type{LaurentPolynomial},  var=Symbollike=:x) =  zero(LaurentPolynomial{Float64}, var)
 Base.zero(p::P, var=Symbollike=:x) where {P  <: LaurentPolynomial} = zero(P, var)
 
@@ -539,7 +537,7 @@ function derivative(p::P, order::Integer = 1) where {T, P<:LaurentPolynomial{T}}
     order < 0 && error("Order of derivative must be non-negative")
     order == 0 && return p
 
-    hasnan(p) && return ⟒(P)(T[NaN], 0:0, p.var)
+    hasnan(p) && return ⟒(P)(T[NaN], 0, p.var)
 
     m,n = (extrema ∘ degreerange)(p)
     m = m - order
@@ -598,7 +596,7 @@ function Base.gcd(p::LaurentPolynomial{T}, q::LaurentPolynomial{T}, args...; kwa
     mp, Mp = (extrema ∘ degreerange)(p)
     mq, Mq = (extrema ∘ degreerange)(q)
     if mp < 0 || mq < 0
-        throw(ArgumentError("GCD is not defined when there are `x⁻¹` terms"))
+        throw(ArgumentError("GCD is not defined when there are `x⁻ⁿ` terms"))
     end
 
     degree(p) == 0 && return iszero(p) ? q : one(q)

--- a/src/polynomials/Polynomial.jl
+++ b/src/polynomials/Polynomial.jl
@@ -44,6 +44,22 @@ end
 
 @register Polynomial
 
+
+function Polynomial{T}(coeffs::OffsetArray{T,1,Array{T,1}}, var::SymbolLike=:x) where {T <: Number}
+    m = firstindex(coeffs)
+    if m < 0
+        ## depwarn
+        Base.depwarn("Use the `LaurentPolynomial` type for offset vectors with negative first index",
+                     :Polynomial)
+        LaurentPolynomial{T}(coeffs, var)
+    else
+        cs = zeros(T, 1 + lastindex(coeffs))
+        cs[1 .+ (firstindex(coeffs):lastindex(coeffs))] = coeffs.parent
+        Polynomial{T}(cs, var)
+    end
+end
+
+
 """
     (p::Polynomial)(x)
 

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -43,13 +43,10 @@ struct SparsePolynomial{T <: Number} <: StandardBasisPolynomial{T}
     coeffs::Dict{Int, T}
     var::Symbol
     function SparsePolynomial{T}(coeffs::Dict{Int, T}, var::SymbolLike) where {T <: Number}
-
         for (k,v)  in coeffs
             iszero(v) && pop!(coeffs,  k)
         end
-        
         new{T}(coeffs, var)
-        
     end
 end
 
@@ -65,12 +62,6 @@ function SparsePolynomial{T}(coeffs::AbstractVector{T}, var::SymbolLike=:x) wher
     return SparsePolynomial{T}(D, var)
 end
 
-function SparsePolynomial(coeffs::Dict{Int, T}, var::SymbolLike=:x) where {T <: Number}
-    SparsePolynomial{T}(coeffs, Symbol(var))
-end
-#function SparsePolynomial(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {T <: Number}
-#    SparsePolynomial{T}(coeffs, Symbol(var))
-#end
 function SparsePolynomial{T}(coeffs::OffsetArray{T,1, Array{T, 1}}, var::SymbolLike=:x) where {T <: Number}
     firstindex(coeffs) >= 0 || throw(ArgumentError("Use the `LaurentPolynomial` type for offset arrays with negative first index"))
     D = Dict{Int, T}()
@@ -80,9 +71,24 @@ function SparsePolynomial{T}(coeffs::OffsetArray{T,1, Array{T, 1}}, var::SymbolL
     SparsePolynomial{T}(D, var)
 end
 
+function SparsePolynomial(coeffs::Dict{Int, T}, var::SymbolLike=:x) where {T <: Number}
+    SparsePolynomial{T}(coeffs, Symbol(var))
+end
+
+
 # Interface through `Polynomial`. As with ImmutablePolynomial, this may not be  good idea...
-Polynomial{T}(coeffs::Dict{Int,T}, var::SymbolLike = :x) where {T} = SparsePolynomial{T}(coeffs, var)
-Polynomial(coeffs::Dict{Int,T}, var::SymbolLike = :x) where {T} = SparsePolynomial{T}(coeffs, var)
+# Deprecated
+function Polynomial{T}(coeffs::Dict{Int,T}, var::SymbolLike = :x) where {T}
+    Base.depwarn("Use of `Polynomial(Dict, var)` is deprecated. Use the `SparsePolynomial` constructor",
+            :Polynomial)
+    SparsePolynomial{T}(coeffs, var)
+end
+
+function Polynomial(coeffs::Dict{Int,T}, var::SymbolLike = :x) where {T}
+    Base.depwarn("Use of `Polynomial(Dict, var)` is deprecated. Use the `SparsePolynomial` constructor",
+                 :Polynomial)
+    SparsePolynomial{T}(coeffs, var)
+end
 
 # conversion
 function Base.convert(P::Type{<:Polynomial}, q::SparsePolynomial)

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -42,7 +42,7 @@ julia> p(1)
 struct SparsePolynomial{T <: Number} <: StandardBasisPolynomial{T}
     coeffs::Dict{Int, T}
     var::Symbol
-    function SparsePolynomial{T}(coeffs::Dict{Int, T}, var::Symbol) where {T <: Number}
+    function SparsePolynomial{T}(coeffs::Dict{Int, T}, var::SymbolLike) where {T <: Number}
 
         for (k,v)  in coeffs
             iszero(v) && pop!(coeffs,  k)
@@ -51,27 +51,33 @@ struct SparsePolynomial{T <: Number} <: StandardBasisPolynomial{T}
         new{T}(coeffs, var)
         
     end
-    function SparsePolynomial{T}(coeffs::AbstractVector{T}, var::Symbol) where {T <: Number}
-
-        D = Dict{Int,T}()
-        for (i,val) in enumerate(coeffs)
-            if !iszero(val)
-                D[i-1] = val
-            end
-        end
-        
-        return new{T}(D, var)
-        
-    end
 end
 
 @register SparsePolynomial
 
+function SparsePolynomial{T}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {T <: Number}
+    D = Dict{Int,T}()
+    for (i,val) in enumerate(coeffs)
+        if !iszero(val)
+            D[i-1] = val
+        end
+    end
+    return SparsePolynomial{T}(D, var)
+end
+
 function SparsePolynomial(coeffs::Dict{Int, T}, var::SymbolLike=:x) where {T <: Number}
     SparsePolynomial{T}(coeffs, Symbol(var))
 end
-function SparsePolynomial(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {T <: Number}
-    SparsePolynomial{T}(coeffs, Symbol(var))
+#function SparsePolynomial(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {T <: Number}
+#    SparsePolynomial{T}(coeffs, Symbol(var))
+#end
+function SparsePolynomial{T}(coeffs::OffsetArray{T,1, Array{T, 1}}, var::SymbolLike=:x) where {T <: Number}
+    firstindex(coeffs) >= 0 || throw(ArgumentError("Use the `LaurentPolynomial` type for offset arrays with negative first index"))
+    D = Dict{Int, T}()
+    for i in eachindex(coeffs)
+        D[i] = coeffs[i]
+    end
+    SparsePolynomial{T}(D, var)
 end
 
 # Interface through `Polynomial`. As with ImmutablePolynomial, this may not be  good idea...

--- a/test/ChebyshevT.jl
+++ b/test/ChebyshevT.jl
@@ -42,6 +42,11 @@ end
     p0 = ChebyshevT([0])
     @test iszero(p0)
     @test degree(p0) == -1
+
+    as = ones(3:4) # offsetvector
+    bs = [0,0,0,1,1]
+    @test ChebyshevT(as) == ChebyshevT(bs)
+    @test ChebyshevT{Float64}(as) == ChebyshevT{Float64}(bs)
 end
 
 @testset "Roots $i" for i in 1:5

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -665,7 +665,7 @@ end
 
     ## Issue #225 and different meanings for "conjugate"
     P = LaurentPolynomial
-    p = P(rand(Complex{Float64}, 4), -1:2)
+    p = P(rand(Complex{Float64}, 4), -1)
     z = rand(Complex{Float64})
     s = imag(z)*im
     @test conj(p)(z) ≈ (conj ∘ p ∘ conj)(z)

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -109,6 +109,13 @@ end
         @test degree(Polynomials.basis(P,5)) == 5
         @test Polynomials.isconstant(P(1))
         @test !Polynomials.isconstant(variable(P))
+
+        # OffsetVector
+        as = ones(3:4) # offsetvector
+        bs = [0,0,0,1,1]
+        @test P(as) == P(bs)
+        @test P{Float64}(as) == P{Float64}(bs)
+
     end
 end
 

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -1,4 +1,5 @@
 using LinearAlgebra
+using OffsetArrays
 
 ## Test standard basis polynomials with (nearly) the same tests
 
@@ -42,7 +43,9 @@ isimmutable(::Type{<:ImmutablePolynomial}) = true
         @test eltype(p) == eltype(coeff)
         @test all([-200, -0.3, 1, 48.2] .∈ domain(p))
     end
+
 end
+        
 
 @testset "Mapdomain" begin
     for P in Ps

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using SpecialFunctions
 using RecipesBase: apply_recipe
 
 import SparseArrays: sparse, nnz
+using OffsetArrays
 
 @testset "Standard basis" begin include("StandardBasis.jl") end
 @testset "ChebyshevT" begin include("ChebyshevT.jl") end


### PR DESCRIPTION
This addresses #261 by adding special cases for the various constructors to handle `OffsetVectors` to indicate the coefficients of a polynomial, as previously done for the `LaurentPolynomial` type.

In the meantime, it deprecates the ill-advised usage of `Polynomial(type)` to create different polynomial types when `type` was a `tuple`, `OffsetVector`, or `Dict`.

A few other cleanups of constructors also was done.