### PR TITLE
Change formulation "overloading"

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ julia> p(0.1)
 
 ### Arithmetic
 
-The usual arithmetic operators are overloaded to work on polynomials, and combinations of polynomials and scalars.
+Methods are added to the usual arithmetic operators so that they work on polynomials, and combinations of polynomials and scalars.
 
 ```julia
 julia> p = Polynomial([1,2])


### PR DESCRIPTION
I have changed a formulation under "Arithmetic" that said that the basic arithmetic operators are overloaded. If I am not mistaken, this is not what it is called in Julia, but it is what it is called in many other languages. I think that what was meant is that methods are added to the basic arithmetic operators, and so, I have changed the formulation accordingly.