### PR TITLE
Fix `roots` eltype when there are no roots

### DIFF
--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -270,7 +270,7 @@ function  roots(p::P; kwargs...)  where  {T, P <: StandardBasisPolynomial{T}}
     R = eltype(one(T)/one(T))
     d = degree(p)
     if d < 1
-        return []
+        return R[]
     end
     d == 1 && return R[-p[0] / p[1]]
 

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -459,6 +459,7 @@ end
         @test sort(roots(p)) ≈ r
 
         @test roots(p0) == roots(p1) == roots(pNULL) == []
+        @test eltype(roots(p0)) == eltype(roots(p1)) == eltype(roots(pNULL)) == Float64
         @test P == LaurentPolynomial ? roots(variable(P)) == [0.0] : roots(P([0,1,0])) == [0.0]
 
         @test roots(p2) == [-1]


### PR DESCRIPTION
```
julia> roots(Polynomial([1.0]))
Any[] # before
Float64[] # after
```
Presumably, that was just an oversight. But getting a non-numeric eltype here can sometimes cause problems downstream.

It now also infers as `Union{Vector{ComplexF64}, Vector{Float64}}` (which is a tight bound), while previously it was inferred as just `Vector`.