### PR TITLE
Fix printing on Julia 1.6

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -52,7 +52,7 @@ Common Printing
 Base.show(io::IO, p::AbstractPolynomial) = show(io, MIME("text/plain"), p)
 
 function Base.show(io::IO, mimetype::MIME"text/plain", p::P) where {P<:AbstractPolynomial}
-    print(io,"$(P.name)(")
+    print(io,"$(P.name.wrapper)(")
     printpoly(io, p, mimetype)
     print(io,")")
 end


### PR DESCRIPTION
Use `P.name.wrapper` instead of `P.name` for printing the type.