### PR TITLE
use qr, not pinv

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -112,7 +112,7 @@ function _fit(P::Type{<:AbstractPolynomial},
     if weights !== nothing
         coeffs = _wlstsq(vand, y, weights)
     else
-        coeffs = pinv(vand) * y
+        coeffs = qr(vand) \ y
     end
     R = float(T)
     return P(R.(coeffs), var)
@@ -122,7 +122,7 @@ end
 # Weighted linear least squares
 _wlstsq(vand, y, W::Number) = _wlstsq(vand, y, fill!(similar(y), W))
 _wlstsq(vand, y, W::AbstractVector) = _wlstsq(vand, y, Diagonal(W))
-_wlstsq(vand, y, W::AbstractMatrix) = (vand' * W * vand) \ (vand' * W * y)
+_wlstsq(vand, y, W::AbstractMatrix) = qr(vand' * W * vand) \ (vand' * W * y)
 
 """
     roots(::AbstractPolynomial; kwargs...)

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -326,6 +326,16 @@ end
 
     # test default   (issue  #228)
     fit(1:3,  rand(3))
+
+    # weight test (PR #291)
+    # This should change with 2.0
+    # as for now we specify w^2.
+    x = range(0, pi, length=30)
+    y = sin.(x)
+    wts = 1 ./ sqrt.(1 .+ x)
+    # cs = numpy.polynomial.polynomial.polyfit(x, y, 4, w=wts)
+    cs = [0.0006441172319036863, 0.985961582190304, 0.04999233434370933, -0.23162369757680354, 0.036864056406570644]
+    @test maximum(abs, coeffs(fit(x, y, 4, weights=wts.^2)) - cs) <= sqrt(eps())
 end
 
 @testset "Values" begin

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -330,7 +330,7 @@ end
     # weight test (PR #291)
     # This should change with 2.0
     # as for now we specify w^2.
-    x = range(0, pi, length=30)
+    x = range(0, stop=pi, length=30)
     y = sin.(x)
     wts = 1 ./ sqrt.(1 .+ x)
     # cs = numpy.polynomial.polynomial.polyfit(x, y, 4, w=wts)


### PR DESCRIPTION
This attempts to address issue #290, but still has issues when a 60 degree polynomial is fit to 60 points (or more). For such, the only suggestion is to use `big` numbers.