### PR TITLE
Improve evaluation of LaurentPolynomial

### DIFF
--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -419,13 +419,13 @@ function (p::LaurentPolynomial{T})(x::S) where {T,S}
     m,n = (extrema ∘ degreerange)(p)
     m  == n == 0 && return p[0] * _one(S)
     if m >= 0
-        evalpoly(x, NTuple{n+1,T}(p[i] for i in 0:n))
+        evalpoly(x, ntuple(i -> p[i-1], n+1)) # NTuple{n+1}(p[i] for i in 0:n)
     elseif n <= 0
-        evalpoly(inv(x), NTuple{-m+1,T}(p[i] for i in 0:-1:m))
+        evalpoly(inv(x), ntuple(i -> p[-i+1], -m+1)) # NTuple{-m+1}(p[i] for i in 0:-1:m)
     else
         # eval pl(x) = a_mx^m + ...+ a_0 at 1/x; pr(x) = a_0 + a_1x + ... + a_nx^n  at  x; subtract a_0
-        l = evalpoly(inv(x), NTuple{-m+1,T}(p[i] for i in 0:-1:m))
-        r =  evalpoly(x, NTuple{n+1,T}(p[i] for i in 0:n))
+        l = evalpoly(inv(x),  ntuple(i -> p[-i+1], -m+1)) # NTuple{-m+1}(p[i] for i in 0:-1:m)
+        r =  evalpoly(x, ntuple(i -> p[i-1], n+1)) # NTuple{n+1}(p[i] for i in 0:n)
         mid = p[0]
         l + r - mid
     end


### PR DESCRIPTION
Use `ntuple` instead of `NTuple` for constructing the coefficient tuples passed to `evalpoly`. This compiles much faster on Julia 1.0 (especially for high-degree polynomials) and is also faster to evaluate even on current Julia.

Julia 1.0.5:
```julia
julia> @time LaurentPolynomial(ones(5))(1)
  0.253496 seconds (990.00 k allocations: 47.603 MiB, 4.10% gc time) # master
  0.861258 seconds (2.45 M allocations: 119.648 MiB, 4.13% gc time) # PR
5.0

julia> @btime LaurentPolynomial(ones(5))(1)
  608.573 ns (12 allocations: 656 bytes) # master
  114.681 ns (8 allocations: 416 bytes) # PR
5.0

julia> @time LaurentPolynomial(ones(150))(1)
 22.524473 seconds (77.11 M allocations: 3.157 GiB, 8.39% gc time) # master
  0.087917 seconds (187.70 k allocations: 9.934 MiB, 3.63% gc time) # PR
150.0

julia> @btime LaurentPolynomial(ones(150))(1)
  375.336 μs (11011 allocations: 265.31 KiB) # master
  6.042 μs (161 allocations: 7.72 KiB) # PR
150.0
```

Julia 1.6.0-DEV.1408:
```julia
julia> @time LaurentPolynomial(ones(5))(1)
  0.076117 seconds (137.39 k allocations: 7.787 MiB, 99.90% compilation time) # master
  0.023298 seconds (26.14 k allocations: 1.687 MiB, 99.86% compilation time) # PR
5.0

julia> @btime LaurentPolynomial(ones(5))(1)
  595.810 ns (10 allocations: 608 bytes) # master
  118.526 ns (6 allocations: 352 bytes) # PR
5.0

julia> @time LaurentPolynomial(ones(150))(1)
  0.089302 seconds (211.92 k allocations: 12.811 MiB, 99.88% compilation time) # master
  0.056672 seconds (170.88 k allocations: 10.229 MiB, 99.90% compilation time) # PR
150.0

julia> @btime LaurentPolynomial(ones(150))(1)
  8.637 μs (161 allocations: 9.00 KiB) # master
  5.936 μs (157 allocations: 7.59 KiB) # PR
150.0
```
The compile time on 1.0.5 grows super-linear, making it impossible to evaluate even higher-order polynomials without this PR.