### PR TITLE
Support BigFloat polynomials

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ author = "JuliaMath"
 version = "1.1.12"
 
 [deps]
+GenericLinearAlgebra = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [compat]
+GenericLinearAlgebra = "0.2"
 Intervals = "0.5, 1.0, 1.3"
 OffsetArrays = "1"
 RecipesBase = "0.7, 0.8, 1"

--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -1,5 +1,6 @@
 module Polynomials
 
+using GenericLinearAlgebra
 using LinearAlgebra
 using Intervals
 using OffsetArrays


### PR DESCRIPTION
Add GenericLinearAlgebra in order to support BigFloat polynomials, e.g.,
```
> roots(derivative(Polynomial(BigFloat[0, 1, -1])^(k-1), k-2))
5-element Array{Complex{BigFloat},1}:
 0.1726731646460114281008537718765708222153959588022877212423398482923665410323274 + 0.0im
 0.4999999999999999999999999999999999999999999999999999999999999999999999999998834 + 0.0im
 0.8273268353539885718991462281234291777846040411977122787576601517076334589676855 - 0.0im
  1.000000000000000000000000000000000000000000000000000000000000000000000000000086 + 0.0im
                                                                               0.0 + 0.0im
```
Currently roots cannot be computed for BigFloat polynomials as `LinearAlgebra.eigvals` does not support BigFloat.