### PR TITLE
Generalize the polynomial constructors to accept AbstractVectors as lists of coefficients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,9 @@ jobs:
             Pkg.instantiate()'
       - run: |
           julia --project=docs -e '
-            using Documenter: doctest
+            using Documenter: doctest, DocMeta
             using Polynomials
+            DocMeta.setdocmeta!(Polynomials, :DocTestSetup, :(using Polynomials); recursive = true)
             doctest(Polynomials)'
       - run: julia --project=docs docs/make.jl
         env:

--- a/test/ChebyshevT.jl
+++ b/test/ChebyshevT.jl
@@ -43,10 +43,14 @@ end
     @test iszero(p0)
     @test degree(p0) == -1
 
-    as = ones(3:4) # offsetvector
-    bs = [0,0,0,1,1]
+    as = ones(3:4)
+    bs = parent(as)
     @test ChebyshevT(as) == ChebyshevT(bs)
     @test ChebyshevT{Float64}(as) == ChebyshevT{Float64}(bs)
+
+    a = [1,1]
+    b = OffsetVector(a, axes(a))
+    @test ChebyshevT(a) == ChebyshevT(b)
 end
 
 @testset "Roots $i" for i in 1:5

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -70,7 +70,7 @@ struct ZVector{T,A<:AbstractVector{T}} <: AbstractVector{T}
 end
 Base.parent(z::ZVector) = z.x
 Base.size(z::ZVector) = size(parent(z))
-Base.axes(z::ZVector) = (Base.IdentityUnitRange(0:size(z,1)-1),)
+Base.axes(z::ZVector) = (OffsetArrays.IdentityUnitRange(0:size(z,1)-1),)
 Base.getindex(z::ZVector, I::Int) = parent(z)[I + z.offset]
 
 @testset "Other Construction" begin

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -141,6 +141,8 @@ Base.getindex(z::ZVector, I::Int) = parent(z)[I + z.offset]
         for P in Ps
             @test P(a) == P(b) == P(c) == P(d)
         end
+
+        @test ImmutablePolynomial{eltype(as), length(as)}(as) == ImmutablePolynomial(bs)
     end
 end
 


### PR DESCRIPTION
Fixes #302 by forcing all constructors to ignore array axes altogether. If desired one may retain the axis information by constructing a `LaurentPolynomial`.

Changes the undocumented behavior of `Polynomial(::OffsetVector)` and such, but overall it should be non-breaking.

Now:

```julia
julia> a = [1,1];

julia> b = OffsetVector(a, axes(a,1));

julia> Polynomial(a) == Polynomial(b)
true

julia> Polynomial(ones(3:4))
┌ Warning: ignoring the axis offset of the coefficient vector
└ @ Polynomials ~/Dropbox/JuliaPackages/Polynomials.jl/src/polynomials/Polynomial.jl:37
Polynomial(1.0 + 1.0*x)
```

Also the constructor is generalized now and should work identically for all `AbstractVector`s. Added a test using a custom array wrapper to confirm this.