### PR TITLE
V2.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,20 +7,20 @@ version = "1.2.0"
 [deps]
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+
 
 [compat]
 Intervals = "0.5, 1.0, 1.3"
-OffsetArrays = "1"
 RecipesBase = "0.7, 0.8, 1"
 julia = "1"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LinearAlgebra", "SparseArrays", "SpecialFunctions", "Test"]
+test = ["LinearAlgebra", "SparseArrays", "OffsetArrays", "SpecialFunctions", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "1.2.0"
+version = "2.0.0"
 
 [deps]
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"

--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ Polynomial objects also have other methods:
 
 * [PolynomialRings](https://github.com/tkluck/PolynomialRings.jl) A library for arithmetic and algebra with multi-variable polynomials.
 
-* [AbstractAlgebra.jl](https://github.com/wbhart/AbstractAlgebra.jl) and [Nemo.jl](https://github.com/wbhart/Nemo.jl) for generic polynomial rings, matrix spaces, fraction fields, residue rings, power series
+* [AbstractAlgebra.jl](https://github.com/wbhart/AbstractAlgebra.jl), [Nemo.jl](https://github.com/wbhart/Nemo.jl) for generic polynomial rings, matrix spaces, fraction fields, residue rings, power series, [Hecke.jl](https://github.com/thofma/Hecke.jl) for algebraic number theory.
+
+* [CommutativeAlgebra](https://github.com/KlausC/CommutativeRings.jl) the start of a computer algebra system specialized to discrete calculations with support for polynomials.
 
 * [PolynomialRoots.jl](https://github.com/giordano/PolynomialRoots.jl) for a fast complex polynomial root finder. For larger degree problems, also [FastPolynomialRoots](https://github.com/andreasnoack/FastPolynomialRoots.jl) and [AMRVW](https://github.com/jverzani/AMRVW.jl).
 

--- a/docs/src/extending.md
+++ b/docs/src/extending.md
@@ -25,9 +25,9 @@ As always, if the default implementation does not work or there are more efficie
 | `domain` | x | Should return an  [`AbstractInterval`](https://invenia.github.io/Intervals.jl/stable/#Intervals-1) |
 | `vander` | | Required for [`fit`](@ref) |
 | `companion` | | Required for [`roots`](@ref) |
-| `fromroots` | | By default, will form polynomials using `prod(variable(::P) - r)` for reach root `r`|
 | `*(::P, ::P)` | | Multiplication of polynomials |
 | `divrem` | | Required for [`gcd`](@ref)|
+| `one`| | Convenience to find constant in new basis |
 | `variable`| | Convenience to find monomial `x` in new  basis|
 
 Check out both the [`Polynomial`](@ref) and [`ChebyshevT`](@ref) for examples of this interface being extended. 
@@ -35,7 +35,7 @@ Check out both the [`Polynomial`](@ref) and [`ChebyshevT`](@ref) for examples of
 ## Example
 
 The following shows a minimal example where the polynomial aliases the vector defining the coefficients. 
-The constructor ensures that there are no trailing zeros. The method implemented below is the convenient call syntax. This example subtypes `StandardBasisPolynomial`, not `AbstractPolynomial`, and consequently inherits the methods above. For other bases,  more methods may be necessary to define  (again, refer to [`ChebyshevT`](@ref) for an example).
+The constructor ensures that there are no trailing zeros. The `@register` call ensures a common interface. This example subtypes `StandardBasisPolynomial`, not `AbstractPolynomial`, and consequently inherits the methods above that otherwise would have been required. For other bases,  more methods may be necessary to define  (again, refer to [`ChebyshevT`](@ref) for an example).
 
 ```jldoctest AliasPolynomial
 julia> using Polynomials
@@ -77,16 +77,15 @@ julia> p(3)
 
 For the `Polynomial` type, the default on operations is to copy the array. For this type, it might seem reasonable -- to avoid allocations -- to update the coefficients in place for scalar addition and scalar multiplication. 
 
-Scalar addition, `p+c`, defaults to `p + c*one(p)`, or polynomial multiplication, which is not inplace without addition work. As such, we create a new method and an infix operator
+Scalar addition, `p+c`, defaults to `p + c*one(p)`, or polynomial addition, which is not inplace without addition work. As such, we create a new method and an infix operator
 
 ```jldoctest AliasPolynomial
-julia> function sadd!(p::AliasPolynomial{T}, c::T) where {T}
+julia> function scalar_add!(p::AliasPolynomial{T}, c::T) where {T}
            p.coeffs[1] += c
            p
        end;
 
-
-julia> p::AliasPolynomial ⊕ c::Number = sadd!(p,c);
+julia> p::AliasPolynomial ⊕ c::Number = scalar_add!(p,c);
 
 ```
 
@@ -103,7 +102,7 @@ julia> p
 AliasPolynomial(3 + 2*x + 3*x^2 + 4*x^3)
 ```
 
-The viewpoint that a polynomial represents a vector of coefficients  leads to a desire to inherit vector operations when possible. Scalar multiplication is a vector operation, so it seems reasonable to override the broadcast machinery to implement an in place operation (e.g. `p .*= 2`). By default, the polynomial types are not broadcastable over their coefficients. We would need to make a change there and modify the `copyto!` function:
+The viewpoint that a polynomial represents a vector of coefficients  leads to an expectation that vector operations should match when possible. Scalar multiplication is a vector operation, so it seems reasonable to override the broadcast machinery to implement an in place operation (e.g. `p .*= 2`). By default, the polynomial types are not broadcastable over their coefficients. We would need to make a change there and modify the `copyto!` function:
 
 
 ```jldoctest AliasPolynomial

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -199,7 +199,7 @@ julia> derivative(p1)
 ChebyshevT(2.0⋅T_0(x) + 12.0⋅T_1(x))
 
 julia> integrate(p2)
-ChebyshevT(0.25⋅T_0(x) - 1.0⋅T_1(x) + 0.25⋅T_2(x) + 0.3333333333333333⋅T_3(x))
+ChebyshevT(- 1.0⋅T_1(x) + 0.25⋅T_2(x) + 0.3333333333333333⋅T_3(x))
 
 julia> convert(Polynomial, p1)
 Polynomial(-2.0 + 2.0*x + 6.0*x^2)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -269,9 +269,9 @@ Polynomial(1 + 2*u + 4*u^3)
 julia> collect(Polynomials.monomials(p))
 4-element Array{Any,1}:
  Polynomial(1)
- Polynomial(2*x)
+ Polynomial(2*u)
  Polynomial(0)
- Polynomial(4*x^3)
+ Polynomial(4*u^3)
 ```
 
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -97,7 +97,7 @@ julia> q = Polynomial([1, 2, 3], :s)
 Polynomial(1 + 2*s + 3*s^2)
 
 julia> p + q
-ERROR: Polynomials must have same variable
+ERROR: ArgumentError: Polynomials have different indeterminates
 [...]
 ```
 
@@ -213,14 +213,67 @@ ChebyshevT(2.5⋅T_0(x) + 2.0⋅T_1(x) + 1.5⋅T_2(x))
 
 ### Iteration
 
-If its basis is implicit, then a polynomial may be  seen as just a vector of  coefficients. Vectors or 1-based, but, for convenience, polynomial types are 0-based, for purposes of indexing (e.g. `getindex`, `setindex!`, `eachindex`). Iteration over a polynomial steps through the basis vectors, e.g. `a_0`, `a_1*x`, ...
+If its basis is implicit, then a polynomial may be  seen as just a vector of  coefficients. Vectors or 1-based, but, for convenience, polynomial types are 0-based, for purposes of indexing (e.g. `getindex`, `setindex!`, `eachindex`). Iteration over a polynomial steps through the underlying coefficients.
 
 ```jldoctest
 julia> as = [1,2,3,4,5]; p = Polynomial(as);
 
 julia> as[3], p[2], collect(p)[3]
-(3, 3, Polynomial(3*x^2))
+(3, 3, 3)
 ```
+
+
+The `pairs` iterator, iterates over the indices and coefficients, attempting to match how `pairs` applies to the underlying storage model:
+
+```jldoctest
+julia> v = [1,2,0,4]
+4-element Array{Int64,1}:
+ 1
+ 2
+ 0
+ 4
+
+julia> p,ip,sp,lp = Polynomial(v), ImmutablePolynomial(v), SparsePolynomial(v), LaurentPolynomial(v, -1);
+
+julia> collect(pairs(p))
+4-element Array{Pair{Int64,Int64},1}:
+ 0 => 1
+ 1 => 2
+ 2 => 0
+ 3 => 4
+
+julia> collect(pairs(ip)) == collect(pairs(p))
+true
+
+julia> collect(pairs(sp)) # unordered dictionary with only non-zero terms
+3-element Array{Pair{Int64,Int64},1}:
+ 0 => 1
+ 3 => 4
+ 1 => 2
+
+julia> collect(pairs(lp))
+4-element Array{Pair{Int64,Int64},1}:
+ -1 => 1
+  0 => 2
+  1 => 0
+  2 => 4
+```
+
+
+The unexported `monomials` iterator iterates over the terms (`p[i]*Polynomials.basis(p,i)`) of the polynomial:
+
+```jldoctest
+julia> p = Polynomial([1,2,0,4], :u)
+Polynomial(1 + 2*u + 4*u^3)
+
+julia> collect(Polynomials.monomials(p))
+4-element Array{Any,1}:
+ Polynomial(1)
+ Polynomial(2*x)
+ Polynomial(0)
+ Polynomial(4*x^3)
+```
+
 
 ## Related Packages
 
@@ -234,9 +287,12 @@ julia> as[3], p[2], collect(p)[3]
 
 * [PolynomialRings](https://github.com/tkluck/PolynomialRings.jl) A library for arithmetic and algebra with multi-variable polynomials.
 
-* [AbstractAlgebra.jl](https://github.com/wbhart/AbstractAlgebra.jl) and [Nemo.jl](https://github.com/wbhart/Nemo.jl) for generic polynomial rings, matrix spaces, fraction fields, residue rings, power series
+* [AbstractAlgebra.jl](https://github.com/wbhart/AbstractAlgebra.jl), [Nemo.jl](https://github.com/wbhart/Nemo.jl) for generic polynomial rings, matrix spaces, fraction fields, residue rings, power series, [Hecke.jl](https://github.com/thofma/Hecke.jl) for algebraic number theory.
+
+* [CommutativeAlgebra](https://github.com/KlausC/CommutativeRings.jl) the start of a computer algebra system specialized to discrete calculations with support for polynomials.
 
 * [PolynomialRoots.jl](https://github.com/giordano/PolynomialRoots.jl) for a fast complex polynomial root finder. For larger degree problems, also [FastPolynomialRoots](https://github.com/andreasnoack/FastPolynomialRoots.jl) and [AMRVW](https://github.com/jverzani/AMRVW.jl).
+
 
 
 

--- a/docs/src/polynomials/chebyshev.md
+++ b/docs/src/polynomials/chebyshev.md
@@ -31,7 +31,7 @@ ChebyshevT(1⋅T_0(x) + 3⋅T_2(x) + 4⋅T_3(x))
 
 
 julia> p = convert(Polynomial, c)
-Polynomial(-2 - 12*x + 6*x^2 + 16*x^3)
+Polynomial(-2.0 - 12.0*x + 6.0*x^2 + 16.0*x^3)
 
 julia> convert(ChebyshevT, p)
 ChebyshevT(1.0⋅T_0(x) + 3.0⋅T_2(x) + 4.0⋅T_3(x))

--- a/src/.#common.jl
+++ b/src/.#common.jl
@@ -1,1 +1,0 @@
-jverzani@john-verzanis-macbook-pro.local.1015

--- a/src/.#common.jl
+++ b/src/.#common.jl
@@ -1,0 +1,1 @@
+jverzani@john-verzanis-macbook-pro.local.1015

--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -26,6 +26,6 @@ include("polynomials/multroot.jl")
 include("polynomials/ChebyshevT.jl")
 
 # compat; opt-in with `using Polynomials.PolyCompat`
-#include("polynomials/Poly.jl")
+include("polynomials/Poly.jl")
 
 end # module

--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -3,7 +3,6 @@ module Polynomials
 #  using GenericLinearAlgebra ## remove for now. cf: https://github.com/JuliaLinearAlgebra/GenericLinearAlgebra.jl/pull/71#issuecomment-743928205
 using LinearAlgebra
 using Intervals
-using OffsetArrays
 
 include("abstract.jl")
 include("show.jl")

--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -23,7 +23,7 @@ include("polynomials/LaurentPolynomial.jl")
 include("polynomials/ngcd.jl")
 include("polynomials/multroot.jl")
 
-#include("polynomials/ChebyshevT.jl")
+include("polynomials/ChebyshevT.jl")
 
 # compat; opt-in with `using Polynomials.PolyCompat`
 #include("polynomials/Poly.jl")

--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -17,11 +17,11 @@ include("common.jl")
 # Polynomials
 include("polynomials/standard-basis.jl")
 include("polynomials/Polynomial.jl")
-#include("polynomials/ImmutablePolynomial.jl")
-#include("polynomials/SparsePolynomial.jl")
-#include("polynomials/LaurentPolynomial.jl")
-#include("polynomials/ngcd.jl")
-#include("polynomials/multroot.jl")
+include("polynomials/ImmutablePolynomial.jl")
+include("polynomials/SparsePolynomial.jl")
+include("polynomials/LaurentPolynomial.jl")
+include("polynomials/ngcd.jl")
+include("polynomials/multroot.jl")
 
 #include("polynomials/ChebyshevT.jl")
 

--- a/src/Polynomials.jl
+++ b/src/Polynomials.jl
@@ -17,15 +17,15 @@ include("common.jl")
 # Polynomials
 include("polynomials/standard-basis.jl")
 include("polynomials/Polynomial.jl")
-include("polynomials/ImmutablePolynomial.jl")
-include("polynomials/SparsePolynomial.jl")
-include("polynomials/LaurentPolynomial.jl")
-include("polynomials/ngcd.jl")
-include("polynomials/multroot.jl")
+#include("polynomials/ImmutablePolynomial.jl")
+#include("polynomials/SparsePolynomial.jl")
+#include("polynomials/LaurentPolynomial.jl")
+#include("polynomials/ngcd.jl")
+#include("polynomials/multroot.jl")
 
-include("polynomials/ChebyshevT.jl")
+#include("polynomials/ChebyshevT.jl")
 
 # compat; opt-in with `using Polynomials.PolyCompat`
-include("polynomials/Poly.jl")
+#include("polynomials/Poly.jl")
 
 end # module

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -18,7 +18,7 @@ abstract type AbstractPolynomial{T,X} end
 
 # convert `as` into polynomial of type P based on instance, inheriting variable
 # (and for LaurentPolynomial the offset)
-_convert(p::P, as) where {P <: AbstractPolynomial} = ⟒(P)(as, indeterminate(P)) 
+_convert(p::P, as) where {P <: AbstractPolynomial} = ⟒(P)(as, indeterminate(P))
 
 """
     Polynomials.@register(name)

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -62,7 +62,6 @@ macro register(name)
         $poly(n::S, var::SymbolLike = :x)  where {S  <: Number} = n * one($poly{S, Symbol(var)})
         $poly{T}(var::SymbolLike=:x) where {T} = variable($poly{T, Symbol(var)})
         $poly(var::SymbolLike=:x) = variable($poly, Symbol(var))
-        _indeterminate(::Type{P}) where {T,X,P<:$poly{T,X}} = X
     end
 end
 
@@ -90,7 +89,6 @@ macro registerN(name, params...)
         $poly{$(αs...)}(n::Number, var::SymbolLike = :x) where {$(αs...)} = n*one($poly{$(αs...)}, Symbol(var))
         $poly{$(αs...),T}(var::SymbolLike=:x) where {$(αs...), T} = variable($poly{$(αs...),T}, Symbol(var))
         $poly{$(αs...)}(var::SymbolLike=:x) where {$(αs...)} = variable($poly{$(αs...)}, Symbol(var))
-        _indeterminate(::Type{P}) where {$(αs...),T,X,P<:$poly{$(αs...),T,X}} = X
     end
 end
 

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -3,7 +3,7 @@ export AbstractPolynomial
 const SymbolLike = Union{AbstractString,Char,Symbol}
 
 """
-    AbstractPolynomial{T}
+    AbstractPolynomial{T,X}
 
 An abstract container for various polynomials. 
 
@@ -27,7 +27,7 @@ Given a polynomial with `name`, creates some common convenience constructors and
 
 # Example
 ```julia
-struct MyPolynomial{T} <: AbstractPolynomial{T} end
+struct MyPolynomial{T,X} <: AbstractPolynomial{T,X} end
 
 Polynomials.@register MyPolynomial
 ```
@@ -72,68 +72,21 @@ macro registerN(name, params...)
     quote
         Base.convert(::Type{P}, q::Q) where {$(αs...),T, P<:$poly{$(αs...),T}, Q <: $poly{$(αs...),T}} = q
         Base.convert(::Type{$poly{$(αs...)}}, q::Q) where {$(αs...),T, Q <: $poly{$(αs...),T}} = q        
-        Base.promote(p::P, q::Q) where {$(αs...),T, P <:$poly{$(αs...),T}, Q <: $poly{$(αs...),T}} = p,q
-        Base.promote_rule(::Type{<:$poly{$(αs...),T}}, ::Type{<:$poly{$(αs...),S}}) where {$(αs...),T,S} =
-            $poly{$(αs...),promote_type(T, S)}
-        Base.promote_rule(::Type{<:$poly{$(αs...),T}}, ::Type{S}) where {$(αs...),T,S<:Number} = 
-            $poly{$(αs...),promote_type(T,S)}
+        Base.promote(p::P, q::Q) where {$(αs...),T, X, P <:$poly{$(αs...),T,X}, Q <: $poly{$(αs...),T,X}} = p,q
+        Base.promote_rule(::Type{<:$poly{$(αs...),T,X}}, ::Type{<:$poly{$(αs...),S,X}}) where {$(αs...),T,S,X} =
+            $poly{$(αs...),promote_type(T, S),X}
+        Base.promote_rule(::Type{<:$poly{$(αs...),T,X}}, ::Type{S}) where {$(αs...),T,X,S<:Number} = 
+            $poly{$(αs...),promote_type(T,S),X}
 
         function $poly{$(αs...),T}(x::AbstractVector{S}, var::SymbolLike = :x) where {$(αs...),T,S}
             $poly{$(αs...),T}(T.(x), Symbol(var))
         end
         $poly{$(αs...)}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {$(αs...),T} =
-            $poly{$(αs...),T}(coeffs, Symbol(var))
+            $poly{$(αs...),T,Symbol(var)}(coeffs)
         $poly{$(αs...),T}(n::Number, var::SymbolLike = :x) where {$(αs...),T} = n*one($poly{$(αs...),T}, Symbol(var))
         $poly{$(αs...)}(n::Number, var::SymbolLike = :x) where {$(αs...)} = n*one($poly{$(αs...)}, Symbol(var))
         $poly{$(αs...),T}(var::SymbolLike=:x) where {$(αs...), T} = variable($poly{$(αs...),T}, Symbol(var))
         $poly{$(αs...)}(var::SymbolLike=:x) where {$(αs...)} = variable($poly{$(αs...)}, Symbol(var))
-    end
-end
-
-
-# deprecated. If desired,  replace with  @registerN  type  parameters... macro
-# Macros to register POLY{α, T} and POLY{α, β, T}
-macro register1(name)
-    @warn "@register1 is deprecated use @registerN"
-    poly = esc(name)
-    quote
-        Base.convert(::Type{P}, p::P) where {P<:$poly} = p
-        Base.promote(p::P, q::Q) where {α,T, P <:$poly{α,T}, Q <: $poly{α,T}} = p,q
-        Base.promote_rule(::Type{<:$poly{α,T}}, ::Type{<:$poly{α,S}}) where {α,T,S} =
-            $poly{α,promote_type(T, S)}
-        Base.promote_rule(::Type{<:$poly{α,T}}, ::Type{S}) where {α,T,S<:Number} = 
-            $poly{α,promote_type(T,S)}
-        function $poly{α,T}(x::AbstractVector{S}, var::SymbolLike = :x) where {α,T,S}
-            $poly{α,T}(T.(x), Symbol(var))
-        end
-        $poly{α}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {α,T} =
-            $poly{α,T}(coeffs, Symbol(var))
-        $poly{α,T}(n::Number, var::SymbolLike = :x) where {α,T} = n*one($poly{α,T}, Symbol(var))
-        $poly{α}(n::Number, var::SymbolLike = :x) where {α} = n*one($poly{α}, Symbol(var))
-        $poly{α,T}(var::SymbolLike=:x) where {α, T} = variable($poly{α,T}, Symbol(var))
-        $poly{α}(var::SymbolLike=:x) where {α} = variable($poly{α}, Symbol(var))
-    end
-end
-
-
-# Macro to register POLY{α, β, T}
-macro register2(name)
-    @warn "@register2  is deprecated use @registerN"
-    poly = esc(name)
-    quote
-        Base.convert(::Type{P}, p::P) where {P<:$poly} = p
-        Base.promote(p::P, q::Q) where {α,β,T, P <:$poly{α,β,T}, Q <: $poly{α,β,T}} = p,q        
-        Base.promote_rule(::Type{<:$poly{α,β,T}}, ::Type{<:$poly{α,β,S}}) where {α,β,T,S} =
-            $poly{α,β,promote_type(T, S)}
-        Base.promote_rule(::Type{<:$poly{α,β,T}}, ::Type{S}) where {α,β,T,S<:Number} =
-            $poly{α,β,promote_type(T, S)}
-        $poly{α,β}(coeffs::AbstractVector{T}, var::SymbolLike = :x) where {α,β,T} =
-            $poly{α,β,T}(coeffs, Symbol(var))
-        $poly{α,β,T}(x::AbstractVector{S}, var::SymbolLike = :x) where {α,β,T,S<:Number} = $poly{α,β,T}(T.(x), var)
-        $poly{α,β,T}(n::Number, var::SymbolLike = :x) where {α,β,T} = n*one($poly{α,β,T}, Symbol(var))
-        $poly{α,β}(n::Number, va::SymbolLiker = :x) where {α,β} = n*one($poly{α,β}, Symbol(var))
-        $poly{α,β,T}(var::SymbolLike=:x) where {α,β, T} = variable($poly{α,β,T}, Symbol(var))
-        $poly{α,β}(var::SymbolLike=:x) where {α,β} = variable($poly{α,β}, Symbol(var))
     end
 end
 

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -58,7 +58,7 @@ macro register(name)
         $poly{T,X}(n::S) where {T, X, S<:Number} =
             n *  one($poly{T, X})
         $poly{T}(n::S, var::SymbolLike = :x) where {T, S<:Number} =
-            n *  one($poly{T}, Symbol(var))
+            n *  one($poly{T, Symbol(var)})
         $poly(n::S, var::SymbolLike = :x)  where {S  <: Number} = n * one($poly{S, Symbol(var)})
         $poly{T}(var::SymbolLike=:x) where {T} = variable($poly{T, Symbol(var)})
         $poly(var::SymbolLike=:x) = variable($poly, Symbol(var))
@@ -86,9 +86,10 @@ macro registerN(name, params...)
 
         $poly{$(αs...),T,X}(n::Number) where {$(αs...),T,X} = n*one($poly{$(αs...),T,X})
         $poly{$(αs...),T}(n::Number, var::SymbolLike = :x) where {$(αs...),T} = n*one($poly{$(αs...),T,Symbol(var)})
-        $poly{$(αs...)}(n::Number, var::SymbolLike = :x) where {$(αs...)} = n*one($poly{$(αs...)}, Symbol(var))
-        $poly{$(αs...),T}(var::SymbolLike=:x) where {$(αs...), T} = variable($poly{$(αs...),T}, Symbol(var))
-        $poly{$(αs...)}(var::SymbolLike=:x) where {$(αs...)} = variable($poly{$(αs...)}, Symbol(var))
+        $poly{$(αs...)}(n::S, var::SymbolLike = :x) where {$(αs...), S<:Number} =
+            n*one($poly{$(αs...),S,Symbol(var)})
+        $poly{$(αs...),T}(var::SymbolLike=:x) where {$(αs...), T} = variable($poly{$(αs...),T,Symbol(var)})
+        $poly{$(αs...)}(var::SymbolLike=:x) where {$(αs...)} = variable($poly{$(αs...)},Symbol(var))
     end
 end
 

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -18,7 +18,7 @@ abstract type AbstractPolynomial{T,X} end
 
 # convert `as` into polynomial of type P based on instance, inheriting variable
 # (and for LaurentPolynomial the offset)
-_convert(p::P, as) where {P <: AbstractPolynomial} = ⟒(P){eltype(as), var(P)}(as)  # ⟒(P)(as, var(P))
+_convert(p::P, as) where {P <: AbstractPolynomial} = ⟒(P)(as, indeterminate(P)) 
 
 """
     Polynomials.@register(name)
@@ -41,10 +41,9 @@ macro register(name)
     poly = esc(name)
     quote
         Base.convert(::Type{P}, p::P) where {P<:$poly} = p
-        Base.convert(P::Type{<:$poly}, p::$poly{T}) where {T} = P(coeffs(p), var(p))
+        Base.convert(P::Type{<:$poly}, p::$poly{T}) where {T} = constructorof(P){eltype(P), indeterminate(P,p)}(coeffs(p))
         Base.promote(p::P, q::Q) where {X, T, P <:$poly{T,X}, Q <: $poly{T,X}} = p,q
-        Base.promote_rule(::Type{<:$poly{T,X}}, ::Type{<:$poly{S,X}}) where {T,S,X} =
-            $poly{promote_type(T, S,X)}
+        Base.promote_rule(::Type{<:$poly{T,X}}, ::Type{<:$poly{S,X}}) where {T,S,X} =  $poly{promote_type(T, S),X}
         Base.promote_rule(::Type{<:$poly{T,X}}, ::Type{S}) where {T,S<:Number,X} =
             $poly{promote_type(T, S),X}
         $poly(coeffs::AbstractVector{T}, var::SymbolLike = :x) where {T} =

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -62,6 +62,7 @@ macro register(name)
         $poly(n::S, var::SymbolLike = :x)  where {S  <: Number} = n * one($poly{S, Symbol(var)})
         $poly{T}(var::SymbolLike=:x) where {T} = variable($poly{T, Symbol(var)})
         $poly(var::SymbolLike=:x) = variable($poly, Symbol(var))
+        _indeterminate(::Type{P}) where {T,X,P<:$poly{T,X}} = X
     end
 end
 
@@ -79,14 +80,17 @@ macro registerN(name, params...)
             $poly{$(αs...),promote_type(T,S),X}
 
         function $poly{$(αs...),T}(x::AbstractVector{S}, var::SymbolLike = :x) where {$(αs...),T,S}
-            $poly{$(αs...),T}(T.(x), Symbol(var))
+            $poly{$(αs...),T, Symbol(var)}(T.(x))
         end
         $poly{$(αs...)}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {$(αs...),T} =
             $poly{$(αs...),T,Symbol(var)}(coeffs)
-        $poly{$(αs...),T}(n::Number, var::SymbolLike = :x) where {$(αs...),T} = n*one($poly{$(αs...),T}, Symbol(var))
+
+        $poly{$(αs...),T,X}(n::Number) where {$(αs...),T,X} = n*one($poly{$(αs...),T,X})
+        $poly{$(αs...),T}(n::Number, var::SymbolLike = :x) where {$(αs...),T} = n*one($poly{$(αs...),T,Symbol(var)})
         $poly{$(αs...)}(n::Number, var::SymbolLike = :x) where {$(αs...)} = n*one($poly{$(αs...)}, Symbol(var))
         $poly{$(αs...),T}(var::SymbolLike=:x) where {$(αs...), T} = variable($poly{$(αs...),T}, Symbol(var))
         $poly{$(αs...)}(var::SymbolLike=:x) where {$(αs...)} = variable($poly{$(αs...)}, Symbol(var))
+        _indeterminate(::Type{P}) where {$(αs...),T,X,P<:$poly{$(αs...),T,X}} = X
     end
 end
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -749,18 +749,18 @@ Base.:-(p1::AbstractPolynomial, p2::AbstractPolynomial) = +(p1, -p2)
 Base.:+(p::P, c::T) where {T,X, P<:AbstractPolynomial{T,X}} = p + c * one(P)
 
 function Base.:+(p::P, c::S) where {T,X, P<:AbstractPolynomial{T,X}, S}
+
     R = promote_type(T,S)
     q = convert(⟒(P){R,X}, p)
     q + R(c)
 end
 
-# polynomial + polynomial
+# polynomial + polynomial when different types
 function Base.:+(p::P, q::Q) where {T,X,P <: AbstractPolynomial{T,X}, S,Y,Q <: AbstractPolynomial{S,Y}}
 
     isconstant(p) && return constantterm(p) + q
     isconstant(q) && return p + constantterm(q)
     assert_same_variable(X,Y)
-    
     sum(promote(p,q))
 
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -704,8 +704,6 @@ variable(var::SymbolLike = :x) = variable(Polynomial{Int}, var)
 
 # basis
 # var is a positional argument, not a keyword; can't deprecate so we do `_var; var=_var`
-#@deprecate basis(p::P, k::Int; var=:x)  where {P<:AbstractPolynomial}  basis(p, k, var)
-#@deprecate basis(::Type{P}, k::Int; var=:x) where {P <: AbstractPolynomial} basis(P, k,var)
 # return the kth basis polynomial for the given polynomial type, e.g. x^k for Polynomial{T}
 function basis(::Type{P}, k::Int, _var::SymbolLike=:x; var=_var) where {P <: AbstractPolynomial}
     zs = zeros(Int, k+1)

--- a/src/common.jl
+++ b/src/common.jl
@@ -277,6 +277,10 @@ Check if either `p` or `q` is constant or if `p` and `q` share the same variable
 check_same_variable(p::AbstractPolynomial, q::AbstractPolynomial) =
     (Polynomials.isconstant(p) || Polynomials.isconstant(q)) || indeterminate(p) ==  indeterminate(q)
 
+function assert_same_variable(p::AbstractPolynomial, q::AbstractPolynomial)
+    check_same_variable(p,q) || throw(ArgumentError("Polynomials have different indeterminates"))
+end
+
 #=
 Linear Algebra =#
 """

--- a/src/common.jl
+++ b/src/common.jl
@@ -527,6 +527,7 @@ export var
 Returns a representation of 0 as the given polynomial.
 """
 Base.zero(::Type{P}, var=:x) where {P <: AbstractPolynomial} = ⟒(P)(zeros(eltype(P), 1), var)
+Base.zero(::Type{P}) where {T, X, P<:AbstractPolynomial{T,X}} = ⟒(P){T,X}(zeros(T,1))
 Base.zero(p::P) where {P <: AbstractPolynomial} = zero(P, var(p))
 """
     one(::Type{<:AbstractPolynomial})
@@ -535,6 +536,7 @@ Base.zero(p::P) where {P <: AbstractPolynomial} = zero(P, var(p))
 Returns a representation of 1 as the given polynomial.
 """
 Base.one(::Type{P}, var=:x) where {P <: AbstractPolynomial} = ⟒(P)(ones(eltype(P),1), var)  # assumes  p₀ = 1
+Base.one(::Type{P}) where {T, X, P<:AbstractPolynomial{T,X}} = ⟒(P){T,X}(ones(T,1))
 Base.one(p::P) where {P <: AbstractPolynomial} = one(P, var(p))
 
 Base.oneunit(::Type{P}, args...) where {P <: AbstractPolynomial} = one(P, args...)
@@ -567,6 +569,7 @@ julia> roots((x - 3) * (x + 2))
 """
 variable(::Type{P}, var::SymbolLike = :x) where {P <: AbstractPolynomial} = MethodError()
 variable(p::AbstractPolynomial, var::SymbolLike = var(p)) = variable(typeof(p), var)
+variable(::Type{P}) where {T,X, P <: AbstractPolynomial{T,X}} = variable(P, X)
 variable(var::SymbolLike = :x) = variable(Polynomial{Int}, var)
 
 # basis
@@ -577,8 +580,14 @@ variable(var::SymbolLike = :x) = variable(Polynomial{Int}, var)
 function basis(::Type{P}, k::Int, _var::SymbolLike=:x; var=_var) where {P <: AbstractPolynomial}
     zs = zeros(Int, k+1)
     zs[end] = 1
-    ⟒(P){eltype(P)}(zs, var)
+    ⟒(P){eltype(P), _var}(zs)
 end
+function basis(::Type{P}, k::Int) where {T, X, P<:AbstractPolynomial{T,X}}
+    zs = zeros(Int, k+1)
+    zs[end] = 1
+    ⟒(P){eltype(P), X}(zs)
+end
+    
 basis(p::P, k::Int, _var::SymbolLike=:x; var=_var) where {P<:AbstractPolynomial} = basis(P, k, var)
 
 #=

--- a/src/common.jl
+++ b/src/common.jl
@@ -275,7 +275,7 @@ end
 Check if either `p` or `q` is constant or if `p` and `q` share the same variable
 """
 check_same_variable(p::AbstractPolynomial, q::AbstractPolynomial) =
-    (Polynomials.isconstant(p) || Polynomials.isconstant(q)) || p.var ==  q.var
+    (Polynomials.isconstant(p) || Polynomials.isconstant(q)) || var(p) ==  var(q)
 
 #=
 Linear Algebra =#
@@ -508,10 +508,18 @@ Base.setindex!(p::AbstractPolynomial, values, ::Colon) =
 #=
 identity =#
 Base.copy(p::P) where {P <: AbstractPolynomial} = _convert(p, copy(coeffs(p)))
-Base.hash(p::AbstractPolynomial, h::UInt) = hash(p.var, hash(coeffs(p), h))
+Base.hash(p::AbstractPolynomial, h::UInt) = hash(var(p), hash(coeffs(p), h))
 
 #=
 zero, one, variable, basis =#
+
+var(::Type{P}) where {T, X, P <: AbstractPolynomial{T,X}} = X
+var(::Type{P}) where {P <: AbstractPolynomial} = :x
+var(p::AbstractPolynomial{T, X}) where {T, X} = X
+export var
+
+
+
 """
     zero(::Type{<:AbstractPolynomial})
     zero(::AbstractPolynomial)
@@ -519,7 +527,7 @@ zero, one, variable, basis =#
 Returns a representation of 0 as the given polynomial.
 """
 Base.zero(::Type{P}, var=:x) where {P <: AbstractPolynomial} = ⟒(P)(zeros(eltype(P), 1), var)
-Base.zero(p::P) where {P <: AbstractPolynomial} = zero(P, p.var)
+Base.zero(p::P) where {P <: AbstractPolynomial} = zero(P, var(p))
 """
     one(::Type{<:AbstractPolynomial})
     one(::AbstractPolynomial)
@@ -527,7 +535,7 @@ Base.zero(p::P) where {P <: AbstractPolynomial} = zero(P, p.var)
 Returns a representation of 1 as the given polynomial.
 """
 Base.one(::Type{P}, var=:x) where {P <: AbstractPolynomial} = ⟒(P)(ones(eltype(P),1), var)  # assumes  p₀ = 1
-Base.one(p::P) where {P <: AbstractPolynomial} = one(P, p.var)
+Base.one(p::P) where {P <: AbstractPolynomial} = one(P, var(p))
 
 Base.oneunit(::Type{P}, args...) where {P <: AbstractPolynomial} = one(P, args...)
 Base.oneunit(p::P, args...) where {P <: AbstractPolynomial} = one(p, args...)
@@ -536,7 +544,7 @@ Base.oneunit(p::P, args...) where {P <: AbstractPolynomial} = one(p, args...)
 """
     variable(var=:x)
     variable(::Type{<:AbstractPolynomial}, var=:x)
-    variable(p::AbstractPolynomial, var=p.var)
+    variable(p::AbstractPolynomial, var=var(p))
 
 Return the monomial `x` in the indicated polynomial basis.  If no type is give, will default to [`Polynomial`](@ref). Equivalent  to  `P(var)`.
 
@@ -558,7 +566,7 @@ julia> roots((x - 3) * (x + 2))
 ```
 """
 variable(::Type{P}, var::SymbolLike = :x) where {P <: AbstractPolynomial} = MethodError()
-variable(p::AbstractPolynomial, var::SymbolLike = p.var) = variable(typeof(p), var)
+variable(p::AbstractPolynomial, var::SymbolLike = var(p)) = variable(typeof(p), var)
 variable(var::SymbolLike = :x) = variable(Polynomial{Int}, var)
 
 # basis

--- a/src/common.jl
+++ b/src/common.jl
@@ -250,6 +250,7 @@ function truncate!(p::AbstractPolynomial{T};
     return chop!(p, rtol = rtol, atol = atol)
 end
 
+## truncate! underlying storage type
 function truncate!(ps::Vector{T};
                    rtol::Real = Base.rtoldefault(real(T)),
                    atol::Real = 0,) where {T}

--- a/src/common.jl
+++ b/src/common.jl
@@ -322,7 +322,7 @@ function chop!(ps::Vector{T};
     tol = norm(ps) * rtol + atol
     for i = lastindex(ps):-1:1
         val = ps[i]
-        if abs(val) > tol #!isapprox(val, zero(T); rtol = rtol, atol = atol)
+        if abs(val) > tol 
             resize!(ps, i); 
             return nothing
         end
@@ -384,7 +384,7 @@ end
 Check if either `p` or `q` is constant or if `p` and `q` share the same variable
 """
 check_same_variable(p::AbstractPolynomial, q::AbstractPolynomial) =
-    (Polynomials.isconstant(p) || Polynomials.isconstant(q)) || indeterminate(p) ==  indeterminate(q)
+    (isconstant(p) || isconstant(q)) || indeterminate(p) ==  indeterminate(q)
 
 function assert_same_variable(p::AbstractPolynomial, q::AbstractPolynomial)
     check_same_variable(p,q) || throw(ArgumentError("Polynomials have different indeterminates"))
@@ -550,7 +550,7 @@ constantterm(p::AbstractPolynomial{T}) where {T} = p(zero(T))
     degree(::AbstractPolynomial)
 
 Return the degree of the polynomial, i.e. the highest exponent in the polynomial that
-has a nonzero coefficient. The degree of the zero polynomial is defined to be -1.
+has a nonzero coefficient. The degree of the zero polynomial is defined to be -1. The default method assumes the basis polynomial, `βₖ` has degree `k`.
 """
 degree(p::AbstractPolynomial) = iszero(p) ? -1 : lastindex(p) 
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -182,11 +182,22 @@ Calculate the psuedo-Vandermonde matrix of the given polynomial type with the gi
 vander(::Type{<:AbstractPolynomial}, x::AbstractVector, deg::Integer)
 
 """
-    integrate(::AbstractPolynomial, C=0)
+    integrate(p::AbstractPolynomial)
 
-Returns the indefinite integral of the polynomial with constant `C`.
+Return an antiderivative for `p`
 """
-integrate(p::AbstractPolynomial, C::Number = 0) = integrate(p, C)
+integrate(P::AbstractPolynomial) = throw(MethodError("`integrate` not implemented for polynomials of type $P"))
+
+"""
+    integrate(::AbstractPolynomial, C)
+
+Returns the indefinite integral of the polynomial with constant `C` when expressed in the standard basis.
+"""
+function integrate(p::P, C) where {P <: AbstractPolynomial}
+    ∫p = integrate(p)
+    isnan(C) && return ⟒(P){eltype(∫p+C), indeterminate(∫p)}([C])
+    ∫p + (-∫p(0) + C)
+end
 
 """
     integrate(::AbstractPolynomial, a, b)

--- a/src/common.jl
+++ b/src/common.jl
@@ -743,7 +743,7 @@ function Base.zero(::Type{P}) where {P<:AbstractPolynomial}
     ⟒(P){T,X}(zeros(T,1))
 end
 Base.zero(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = zero(⟒(P){eltype(P),Symbol(var)}) #default 0⋅b₀
-Base.zero(p::P) where {P <: AbstractPolynomial} = zero(P, indeterminate(p))
+Base.zero(p::P, var=indeterminate(p)) where {P <: AbstractPolynomial} = zero(P, var)
 """
     one(::Type{<:AbstractPolynomial})
     one(::AbstractPolynomial)
@@ -751,8 +751,8 @@ Base.zero(p::P) where {P <: AbstractPolynomial} = zero(P, indeterminate(p))
 Returns a representation of 1 as the given polynomial.
 """
 Base.one(::Type{P}) where {P<:AbstractPolynomial} = throw(ArgumentError("No default method defined")) # no default method
-Base.one(::Type{P}, var) where {P <: AbstractPolynomial} = one(⟒(P){eltype(P), Symbol(var == nothing ? :x : var)})
-Base.one(p::P) where {P <: AbstractPolynomial} = one(P)
+Base.one(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = one(⟒(P){eltype(P), Symbol(var == nothing ? :x : var)})
+Base.one(p::P, var=indeterminate(p)) where {P <: AbstractPolynomial} = one(P, var)
 
 Base.oneunit(::Type{P}, args...) where {P <: AbstractPolynomial} = one(P, args...)
 Base.oneunit(p::P, args...) where {P <: AbstractPolynomial} = one(p, args...)
@@ -784,7 +784,7 @@ julia> roots((x - 3) * (x + 2))
 """
 variable(::Type{P}) where {P <: AbstractPolynomial} = throw(ArgumentError("No default method defined")) # no default
 variable(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = variable(⟒(P){eltype(P),Symbol(var)})
-variable(p::AbstractPolynomial, var::SymbolLike = indeterminate(p)) = variable(typeof(p), var)
+variable(p::AbstractPolynomial, var = indeterminate(p)) = variable(typeof(p), var)
 variable(var::SymbolLike = :x) = variable(Polynomial{Int}, var)
 
 # basis
@@ -800,7 +800,7 @@ function basis(::Type{P}, k::Int, _var::SymbolLike; var=_var) where {P <: Abstra
     T,X = eltype(P), Symbol(var)
     basis(⟒(P){T,X}, k)
 end
-basis(p::P, k::Int, _var::SymbolLike=:x; var=_var) where {P<:AbstractPolynomial} = basis(P, k, var)
+basis(p::P, k::Int, _var=indeterminate(p); var=_var) where {P<:AbstractPolynomial} = basis(P, k, var)
 
 #=
 arithmetic =#

--- a/src/common.jl
+++ b/src/common.jl
@@ -241,7 +241,7 @@ In-place version of [`chop`](@ref)
 function chop!(p::AbstractPolynomial{T};
     rtol::Real = Base.rtoldefault(real(T)),
                atol::Real = 0,) where {T}
-    isempty(values(p)) && return p
+    isempty(coeffs(p)) && return p
     tol = norm(p) * rtol + atol
     for i = lastindex(p):-1:0
         val = p[i]
@@ -581,11 +581,14 @@ Base.hash(p::AbstractPolynomial, h::UInt) = hash(indeterminate(p), hash(coeffs(p
 zero, one, variable, basis =#
 
 # get symbol of polynomial. (e.g. `:x` from 1x^2 + 2x^3...
-_indeterminate(::Type{P}) where {T, X, P <: AbstractPolynomial{T, X}} = X
+#_indeterminate(::Type{P}) where {T, X, P <: AbstractPolynomial{T, X}} = X
 _indeterminate(::Type{P}) where {P <: AbstractPolynomial} = nothing
-indeterminate(::Type{P}) where {T, X, P <: AbstractPolynomial{T,X}} = X
-indeterminate(::Type{P}) where {P <: AbstractPolynomial} = :x
-indeterminate(p::AbstractPolynomial{T, X}) where {T, X} = X
+_indeterminate(::Type{P}) where {T, X, P <: AbstractPolynomial{T,X}} = X
+function indeterminate(::Type{P}) where {P <: AbstractPolynomial}
+    X = _indeterminate(P)
+    X == nothing ? :x : X
+end
+indeterminate(p::P) where {P <: AbstractPolynomial} = _indeterminate(P)
 function indeterminate(PP::Type{P}, p::AbstractPolynomial) where {P <: AbstractPolynomial}
     X = _indeterminate(PP) == nothing ? indeterminate(p) :  _indeterminate(PP)
 end
@@ -734,7 +737,7 @@ function Base.gcd(p1::AbstractPolynomial{T}, p2::AbstractPolynomial{T};
     while !iszero(r₁) && iter ≤ itermax
         _, rtemp = divrem(r₀, r₁)
         r₀ = r₁
-        r₁ = truncate(rtemp; atol=atol, rtol=rtol)  
+        r₁ = truncate(rtemp; atol=atol, rtol=rtol)
         iter += 1
     end
     return r₀

--- a/src/common.jl
+++ b/src/common.jl
@@ -705,17 +705,15 @@ variable(var::SymbolLike = :x) = variable(Polynomial{Int}, var)
 # basis
 # var is a positional argument, not a keyword; can't deprecate so we do `_var; var=_var`
 # return the kth basis polynomial for the given polynomial type, e.g. x^k for Polynomial{T}
-function basis(::Type{P}, k::Int, _var::SymbolLike=:x; var=_var) where {P <: AbstractPolynomial}
-    zs = zeros(Int, k+1)
-    zs[end] = 1
-    ⟒(P){eltype(P), _var}(zs)
-end
 function basis(::Type{P}, k::Int) where {T, X, P<:AbstractPolynomial{T,X}}
     zs = zeros(Int, k+1)
     zs[end] = 1
     ⟒(P){eltype(P), X}(zs)
 end
-    
+function basis(::Type{P}, k::Int, _var::SymbolLike=:x; var=_var) where {P <: AbstractPolynomial}
+    T,X = eltype(P), Symbol(_var)
+    basis(⟒(P){T,X},k)
+end
 basis(p::P, k::Int, _var::SymbolLike=:x; var=_var) where {P<:AbstractPolynomial} = basis(P, k, var)
 
 #=

--- a/src/common.jl
+++ b/src/common.jl
@@ -331,7 +331,13 @@ Base.eltype(p::AbstractPolynomial{T}) where {T} = T
 # in  analogy  with  polynomial as a Vector{T} with different operations defined.
 Base.eltype(::Type{<:AbstractPolynomial}) = Float64
 Base.eltype(::Type{<:AbstractPolynomial{T}}) where {T} = T
-#Base.eltype(::Type{P}) where {P <: AbstractPolynomial} = P # changed  in v1.1.0
+_eltype(::Type{<:AbstractPolynomial}) = nothing
+_eltype(::Type{<:AbstractPolynomial{T}}) where {T} = T
+function _eltype(P::Type{<:AbstractPolynomial}, p::AbstractPolynomial)
+    T′ = _eltype(P)
+    T = T′ == nothing ? eltype(p) : T′
+    T
+end
 Base.iszero(p::AbstractPolynomial) = all(iszero, p)
 
 # See discussions in https://github.com/JuliaMath/Polynomials.jl/issues/258
@@ -592,6 +598,10 @@ indeterminate(p::P) where {P <: AbstractPolynomial} = _indeterminate(P)
 function indeterminate(PP::Type{P}, p::AbstractPolynomial) where {P <: AbstractPolynomial}
     X = _indeterminate(PP) == nothing ? indeterminate(p) :  _indeterminate(PP)
 end
+function indeterminate(PP::Type{P}, x::Symbol) where {P <: AbstractPolynomial}
+    X = _indeterminate(PP) == nothing ? x :  _indeterminate(PP)
+end
+
 
 
 """

--- a/src/common.jl
+++ b/src/common.jl
@@ -70,19 +70,41 @@ fromroots(A::AbstractMatrix{T}; var::SymbolLike = :x) where {T <: Number} =
     fit(::Type{<:AbstractPolynomial}, x, y, deg=length(x)-1; [weights], var=:x)
 
 Fit the given data as a polynomial type with the given degree. Uses
-linear least squares to minimize the norm of `V⋅c - y`, where `V` is
-the Vandermonde matrix and `c` are the coefficients of the polynomial
+linear least squares to minimize the norm  `||y - V⋅β||^2`, where `V` is
+the Vandermonde matrix and `β` are the coefficients of the polynomial
 fit.
 
 This will automatically scale your data to the [`domain`](@ref) of the
 polynomial type using [`mapdomain`](@ref). The default polynomial type
 is [`Polynomial`](@ref).
 
-When weights are given, as either a `Number`, `Vector` or `Matrix`,
-this will use weighted linear least squares. That is, the norm of
-`W ⋅ (y - V ⋅ x)` is minimized. (As of now, the weights are specified 
-using their squares: for a number use `w^2`, for a vector `wᵢ^2`, and for a matrix
- specify `W'*W`. This behavior may change in the future.)
+
+## Weights
+
+Weights may be assigned to the points by specifying a vector or matrix of weights. 
+
+When specified as a vector, `[w₁,…,wₙ]`, the weights should be
+non-negative as the minimization problem is `argmin_β Σᵢ wᵢ |yᵢ - Σⱼ
+Vᵢⱼ βⱼ|² = argmin_β || √(W)⋅(y - V(x)β)||²`, where, `W` the digonal
+matrix formed from `[w₁,…,wₙ]`, is used for the solution, `V` being
+the Vandermonde matrix of `x` corresponding to the specified
+degree. This parameterization of the weights is different from that of
+`numpy.polyfit`, where the weights would be specified through 
+`[ω₁,ω₂,…,ωₙ] = [√w₁, √w₂,…,√wₙ]` 
+with the answer solving 
+`argminᵦ | (ωᵢ⋅yᵢ- ΣⱼVᵢⱼ(ω⋅x) βⱼ) |^2`.
+
+When specified as a matrix, `W`, the solution is through the normal
+equations `(VᵀWV)β = (Vᵀy)`, again `V` being the Vandermonde matrix of
+`x` corresponding to the specified degree.
+
+(In statistics, the vector case corresponds to weighted least squares,
+where weights are typically given by `wᵢ = 1/σᵢ²`, the `σᵢ²` being the
+variance of the measurement; the matrix specification follows that of
+the generalized least squares estimator with `W = Σ⁻¹`, the inverse of
+the variance-covariance matrix.)
+
+## large degree
 
 For fitting with a large degree, the Vandermonde matrix is exponentially ill-conditioned. The [`ArnoldiFit`](@ref) type introduces an Arnoldi orthogonalization that fixes this problem.
 
@@ -136,7 +158,6 @@ end
 
 
 # Weighted linear least squares
-# TODO: Breaking change for 2.0: use non-squared weights
 _wlstsq(vand, y, W::Number) = _wlstsq(vand, y, fill!(similar(y), W))
 function _wlstsq(vand, y, w::AbstractVector)
     W = Diagonal(sqrt.(w))

--- a/src/common.jl
+++ b/src/common.jl
@@ -759,7 +759,7 @@ function Base.isapprox(p1::AbstractPolynomial{T,X},
     rtol::Real = (Base.rtoldefault(T, S, 0)),
                        atol::Real = 0,) where {T,X,S,Y}
 #    p1, p2 = promote(p1, p2)
-    check_same_variable(p1, p2)  || error("p1 and p2 must have same var")
+    check_same_variable(p1, p2)  || throw(ArgumentError("p1 and p2 must have same var"))
     # copy over from abstractarray.jl
     Δ  = norm(p1-p2)
     if isfinite(Δ)

--- a/src/pade.jl
+++ b/src/pade.jl
@@ -1,6 +1,8 @@
 module PadeApproximation
 
 using ..Polynomials
+indeterminate = Polynomials.indeterminate
+
 using ..PolyCompat
 export Pade, padeval
 
@@ -27,8 +29,8 @@ struct Pade{T <: Number,S <: Number}
     q::Union{Poly{S}, Polynomial{S}}
     var::Symbol
     function Pade{T,S}(p::Union{Poly{T}, Polynomial{T}}, q::Union{Poly{S}, Polynomial{S}}) where {T,S}
-        if p.var != q.var error("Polynomials must have same variable") end
-        new{T,S}(p, q, p.var)
+        if indeterminate(p) != indeterminate(q) error("Polynomials must have same variable") end
+        new{T,S}(p, q, indeterminate(p))
     end
 end
 
@@ -36,10 +38,10 @@ Pade(p::Polynomial{T}, q::Polynomial{S}) where {T <: Number,S <: Number} = Pade{
 
 function Pade(c::Polynomial{T}, m::Integer, n::Integer) where {T}
     m + n < length(c) || error("m + n must be less than the length of the Polynomial")
-    rold = Polynomial([zeros(T, m + n + 1);one(T)], c.var)
-    rnew = Polynomial(c[0:m + n], c.var)
-    uold = Polynomial([one(T)], c.var)
-    vold = Polynomial([zero(T)], c.var)
+    rold = Polynomial([zeros(T, m + n + 1);one(T)], indeterminate(c))
+    rnew = Polynomial(c[0:m + n], indeterminate(c))
+    uold = Polynomial([one(T)], indeterminate(c))
+    vold = Polynomial([zero(T)], indeterminate(c))
     unew, vnew = vold, uold
     @inbounds for i = 1:n
         temp0, temp1, temp2 = rnew, unew, vnew
@@ -61,10 +63,10 @@ Pade(p::Poly{T}, q::Poly{S}) where {T <: Number,S <: Number} = Pade{T,S}(p, q)
 
 function Pade(c::Poly{T}, m::Integer, n::Integer) where {T}
     m + n < length(c) || error("m + n must be less than the length of the polynomial")
-    rold = Poly([zeros(T, m + n + 1);one(T)], c.var)
-    rnew = Poly(c[0:m + n], c.var)
-    uold = Poly([one(T)], c.var)
-    vold = Poly([zero(T)], c.var)
+    rold = Poly([zeros(T, m + n + 1);one(T)], indeterminate(c))
+    rnew = Poly(c[0:m + n], indeterminate(c))
+    uold = Poly([one(T)], indeterminate(c))
+    vold = Poly([zero(T)], indeterminate(c))
     unew, vnew = vold, uold
     @inbounds for i = 1:n
         temp0, temp1, temp2 = rnew, unew, vnew

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -68,11 +68,15 @@ Base.convert(C::Type{<:ChebyshevT}, p::Polynomial) = p(variable(C))
 
 
 domain(::Type{<:ChebyshevT}) = Interval(-1, 1)
-function variable(P::Type{<:ChebyshevT}, var::SymbolLike)
-    X′ = _indeterminate(P)
-    X = X′ == nothing ? Symbol(var) : X′
-    ⟒(P){eltype(P), X}([0, 1])
+function Base.one(::Type{P}) where {P<:ChebyshevT}
+    T,X = eltype(P), indeterminate(P)
+    ChebyshevT{T,X}(ones(T,1))
 end
+function variable(::Type{P}) where {P<:ChebyshevT}
+    T,X = eltype(P), indeterminate(P)
+    ChebyshevT{T,X}([zero(T), one(T)])
+end
+constantterm(p::ChebyshevT) = p(0)
 """
     (::ChebyshevT)(x)
 
@@ -110,7 +114,6 @@ function evalpoly(x::S, ch::ChebyshevT{T}) where {T,S}
     return R(c0 + c1 * x)
 end
 
-constantterm(p::ChebyshevT) = p(0)
 
 function vander(P::Type{<:ChebyshevT}, x::AbstractVector{T}, n::Integer) where {T <: Number}
     A = Matrix{T}(undef, length(x), n + 1)

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -36,7 +36,7 @@ struct ChebyshevT{T <: Number, X} <: AbstractPolynomial{T, X}
         end
 
         N = findlast(!iszero, coeffs)
-        isnothing(N) && return new{T,X}(zeros(T,1))
+        N == nothing && return new{T,X}(zeros(T,1))
         cs = T[coeffs[i] for i ∈ firstindex(coeffs):N]
         new{T,X}(cs)
     end
@@ -185,7 +185,7 @@ end
 
 function Base.:+(p1::ChebyshevT{T,X}, p2::ChebyshevT{S,Y}) where {T,X,S,Y}
     X′ = isconstant(p2) ? X : Y
-    (!isconstant(p1) && !isconstant(p2)) && X != Y && throw(ArgumentError("Polynomials must have same variable"))
+    assert_same_variable(p1, p2)
     n = max(length(p1), length(p2))
     R =  promote_type(T,S)
     c = R[p1[i] + p2[i] for i = 0:n]
@@ -195,7 +195,7 @@ end
 
 function Base.:*(p1::ChebyshevT{T,X}, p2::ChebyshevT{S,Y}) where {T,X,S,Y}
     X′ = isconstant(p2) ? X : Y
-    (!isconstant(p1) && !isconstant(p2)) &&     X != Y && throw(ArgumentError("Polynomials must have same variable"))
+    assert_same_variable(p1, p2)
     z1 = _c_to_z(p1.coeffs)
     z2 = _c_to_z(p2.coeffs)
     prod = fastconv(z1, z2)
@@ -205,7 +205,7 @@ function Base.:*(p1::ChebyshevT{T,X}, p2::ChebyshevT{S,Y}) where {T,X,S,Y}
 end
 
 function Base.divrem(num::ChebyshevT{T,X}, den::ChebyshevT{S,Y}) where {T,X,S,Y}
-    X != Y && throw(ArgumentError("Polynomials must have same variable"))
+    assert_same_variable(num, den)
     n = length(num) - 1
     m = length(den) - 1
 

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -66,6 +66,7 @@ end
 Base.convert(C::Type{<:ChebyshevT}, p::Polynomial) = p(variable(C))
 
 
+
 domain(::Type{<:ChebyshevT}) = Interval(-1, 1)
 function variable(P::Type{<:ChebyshevT}, var::SymbolLike)
     X′ = _indeterminate(P)
@@ -109,7 +110,7 @@ function (ch::ChebyshevT{T})(x::S) where {T,S}
     return R(c0 + c1 * x)
 end
 
-constantterm(p::ChebyshevT) = p[0]
+constantterm(p::ChebyshevT) = p(0)
 
 function vander(P::Type{<:ChebyshevT}, x::AbstractVector{T}, n::Integer) where {T <: Number}
     A = Matrix{T}(undef, length(x), n + 1)
@@ -193,7 +194,7 @@ function Base.:+(p::ChebyshevT{T,X}, c::S) where {T,X, S<:Number}
     R = promote_type(T,S)
     cs = collect(R, values(p))
     cs[1] += c
-    ChebyshevT{T,X}(cs)
+    ChebyshevT{R,X}(cs)
 end
 function Base.:+(p::P, c::T) where {T,X,P<:ChebyshevT{T,X}}
     cs = collect(T, values(p))

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -30,16 +30,15 @@ ChebyshevT(1.0⋅T_0(x))
 struct ChebyshevT{T <: Number, X} <: AbstractPolynomial{T, X}
     coeffs::Vector{T}
     function ChebyshevT{T, X}(coeffs::AbstractVector{S}) where {T <: Number,X, S}
-        length(coeffs) == 0 && return new{T,X}(zeros(T, 1))
+
         if Base.has_offset_axes(coeffs)
-            # throw(ArgumentError("The `ChebyshevT` constructor does not accept `OffsetArrays`. Try `LaurentPolynomial`."))
-            
             @warn "ignoring the axis offset of the coefficient vector"
-            coeffs = OffsetArrays.no_offset_view(coeffs) 
         end
-        last_nz = findlast(!iszero, coeffs)
-        last = max(1, last_nz === nothing ? 0 : last_nz)
-        return new{T,X}(convert(Vector{T}, coeffs[1:last]))
+
+        N = findlast(!iszero, coeffs)
+        isnothing(N) && return new{T,X}(zeros(T,1))
+        cs = T[coeffs[i] for i ∈ firstindex(coeffs):N]
+        new{T,X}(cs)
     end
 end
 

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -119,14 +119,15 @@ function vander(P::Type{<:ChebyshevT}, x::AbstractVector{T}, n::Integer) where {
     return A
 end
 
-function integrate(p::ChebyshevT{T}, C::S) where {T,S <: Number}
+function integrate(p::ChebyshevT{T,X}, C::S) where {T,X,S <: Number}
     R = promote_type(eltype(one(T) / 1), S)
+    Q = ChebyshevT{R,X}
     if hasnan(p) || isnan(C)
-        return ChebyshevT([NaN])
+        return Q([NaN])
     end
     n = length(p)
     if n == 1
-        return ChebyshevT{R}([C, p[0]])
+        return Q([C, p[0]])
     end
     a2 = Vector{R}(undef, n + 1)
     a2[1] = zero(R)
@@ -137,7 +138,7 @@ function integrate(p::ChebyshevT{T}, C::S) where {T,S <: Number}
         a2[i] -= p[i] / (2 * (i - 1))
     end
     a2[1] += R(C) - ChebyshevT(a2)(0)
-    return ChebyshevT(a2, indeterminate(p))
+    return Q(a2)
 end
 
 

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -94,7 +94,7 @@ julia> c.(-1:0.5:1)
 ```
 """
 function (ch::ChebyshevT{T})(x::S) where {T,S}
-    x ∉ domain(ch) && error("$x outside of domain")
+    x ∉ domain(ch) && throw(ArgumentError("$x outside of domain"))
     R = promote_type(T, S)
     length(ch) == 0 && return zero(R)
     length(ch) == 1 && return R(ch[0])
@@ -169,7 +169,7 @@ end
 
 function companion(p::ChebyshevT{T}) where T
     d = length(p) - 1
-    d < 1 && error("Series must have degree greater than 1")
+    d < 1 && throw(ArgumentError("Series must have degree greater than 1"))
     d == 1 && return diagm(0 => [-p[0] / p[1]])
     R = eltype(one(T) / one(T))
 
@@ -185,7 +185,7 @@ end
 
 function Base.:+(p1::ChebyshevT{T,X}, p2::ChebyshevT{S,Y}) where {T,X,S,Y}
     X′ = isconstant(p2) ? X : Y
-    (!isconstant(p1) && !isconstant(p2)) && X != Y && error("Polynomials must have same variable")
+    (!isconstant(p1) && !isconstant(p2)) && X != Y && throw(ArgumentError("Polynomials must have same variable"))
     n = max(length(p1), length(p2))
     R =  promote_type(T,S)
     c = R[p1[i] + p2[i] for i = 0:n]
@@ -195,7 +195,7 @@ end
 
 function Base.:*(p1::ChebyshevT{T,X}, p2::ChebyshevT{S,Y}) where {T,X,S,Y}
     X′ = isconstant(p2) ? X : Y
-    (!isconstant(p1) && !isconstant(p2)) &&     X != Y && error("Polynomials must have same variable")
+    (!isconstant(p1) && !isconstant(p2)) &&     X != Y && throw(ArgumentError("Polynomials must have same variable"))
     z1 = _c_to_z(p1.coeffs)
     z2 = _c_to_z(p2.coeffs)
     prod = fastconv(z1, z2)
@@ -205,7 +205,7 @@ function Base.:*(p1::ChebyshevT{T,X}, p2::ChebyshevT{S,Y}) where {T,X,S,Y}
 end
 
 function Base.divrem(num::ChebyshevT{T,X}, den::ChebyshevT{S,Y}) where {T,X,S,Y}
-    X != Y && error("Polynomials must have same variable")
+    X != Y && throw(ArgumentError("Polynomials must have same variable"))
     n = length(num) - 1
     m = length(den) - 1
 

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -121,15 +121,15 @@ function vander(P::Type{<:ChebyshevT}, x::AbstractVector{T}, n::Integer) where {
     return A
 end
 
-function integrate(p::ChebyshevT{T,X}, C::S) where {T,X,S <: Number}
-    R = promote_type(eltype(one(T) / 1), S)
+function integrate(p::ChebyshevT{T,X}) where {T,X}
+    R = eltype(one(T) / 1)
     Q = ChebyshevT{R,X}
-    if hasnan(p) || isnan(C)
+    if hasnan(p)
         return Q([NaN])
     end
     n = length(p)
     if n == 1
-        return Q([C, p[0]])
+        return Q([zero(R), p[0]])
     end
     a2 = Vector{R}(undef, n + 1)
     a2[1] = zero(R)
@@ -139,7 +139,7 @@ function integrate(p::ChebyshevT{T,X}, C::S) where {T,X,S <: Number}
         a2[i + 2] = p[i] / (2 * (i + 1))
         a2[i] -= p[i] / (2 * (i - 1))
     end
-    a2[1] += R(C) - ChebyshevT(a2)(0)
+
     return Q(a2)
 end
 

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -162,8 +162,8 @@ function Base.truncate(p::ImmutablePolynomial{T,X,N};
 end
 
 # no in-place chop! and truncate!
-chop!(p::ImmutablePolynomial; kwargs...) =  chop(p; kwargs...)
-truncate!(p::ImmutablePolynomial; kwargs...) =  truncate(p; kwargs...)
+chop!(p::ImmutablePolynomial; kwargs...) =  throw(MethodError("No `chop!` for the `ImmutablePolynomial` type. Use `chop`?")) 
+truncate!(p::ImmutablePolynomial; kwargs...) =  throw(MethodError("No `truncate!` for the `ImmutablePolynomial` type. Use `trunctate`?")) 
 
 ##
 ## --------------------
@@ -197,7 +197,6 @@ function Base.:+(p1::ImmutablePolynomial{T,X,N}, p2::ImmutablePolynomial{S,Y,M})
 
 end
 
-# not type stable!!!
 function Base.:*(p1::ImmutablePolynomial{T,X,N}, p2::ImmutablePolynomial{S,Y,M}) where {T,X,N,S,Y,M}
     isconstant(p1) && return p2 * p1[0] 
     isconstant(p2) && return p1 * p2[0]

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -181,7 +181,7 @@ function Base.:+(p1::ImmutablePolynomial{T,X,N}, p2::ImmutablePolynomial{S,Y,M})
     if X != Y
         isconstant(p1) && return ImmutablePolynomial{T,Y,1}(p1.coeffs) + p2 
         isconstant(p2) && return p1 + ImmutablePolynomial{S,X,1}(p2.coeffs)
-        error("Polynomials must have same variable")
+        throw(ArgumentError("Polynomials must have same variable"))
     end
 
     if  N == M
@@ -200,7 +200,7 @@ end
 function Base.:*(p1::ImmutablePolynomial{T,X,N}, p2::ImmutablePolynomial{S,Y,M}) where {T,X,N,S,Y,M}
     isconstant(p1) && return p2 * p1[0] 
     isconstant(p2) && return p1 * p2[0]
-    X != Y && error("Polynomials must have same variable")
+    X != Y && throw(ArgumentError("Polynomials must have same variable"))
     R = promote_type(S,T)
     cs = (p1.coeffs) ⊗ (p2.coeffs)
     if !iszero(cs[end])

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -171,17 +171,26 @@ truncate!(p::ImmutablePolynomial; kwargs...) =  throw(MethodError("No `truncate!
 
 (p::ImmutablePolynomial{T,X,N})(x::S) where {T,X,N,S} = evalpoly(x, p.coeffs)
 
-function Base.:+(p1::ImmutablePolynomial{T,X,N}, p2::ImmutablePolynomial{T,X,M}) where {T,X,N,M}
+function Base.:+(p1::P, p2::Q) where {T,X,N,P<:ImmutablePolynomial{T,X,N},
+                                      S,  M,Q<:ImmutablePolynomial{S,X,M}}
 
+    R = promote_type(T,S)
     if  N == M
-        cs = (p1.coeffs) ⊕ (p2.coeffs) #NTuple{N,T}(p1[i] + p2[i] for i in 0:N-1)
-        ImmutablePolynomial{T,X}(cs)        
+        cs = ⊕(P, p1.coeffs, p2.coeffs)
+        return ImmutablePolynomial{R,X}(R.(cs))
+        #cs = (p1.coeffs) ⊕ (p2.coeffs) #NTuple{N,T}(p1[i] + p2[i] for i in 0:N-1)
+        #ImmutablePolynomial{T,X}(cs)        
     elseif N < M
-        cs = (p2.coeffs) ⊕ (p1.coeffs)
-        ImmutablePolynomial{T,X,M}(convert(NTuple{M,T}, cs))
+        cs = ⊕(P, p2.coeffs, p1.coeffs)
+        return ImmutablePolynomial{R,X,M}(R.(cs))
+        
+        #cs = (p2.coeffs) ⊕ (p1.coeffs)
+        #ImmutablePolynomial{T,X,M}(convert(NTuple{M,T}, cs))
     else
-        cs = (p1.coeffs) ⊕ (p2.coeffs)
-        ImmutablePolynomial{T,X,N}(convert(NTuple{N,T}, cs))
+        cs = ⊕(P, p1.coeffs, p2.coeffs)
+        return ImmutablePolynomial{R,X,N}(R.(cs))
+        #cs = (p1.coeffs) ⊕ (p2.coeffs)
+        #ImmutablePolynomial{T,X,N}(convert(NTuple{N,T}, cs))
     end
 
 end

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -66,7 +66,7 @@ function ImmutablePolynomial{T,X}(coeffs::AbstractVector{S})  where {T,X,S}
         @warn "ignoring the axis offset of the coefficient vector"
     end
     N = findlast(!iszero, coeffs)
-    isnothing(N) && return ImmutablePolynomial{R,X,0}(())
+    N = nothing && return ImmutablePolynomial{R,X,0}(())
     N′ = N + 1 - firstindex(coeffs)
     cs = NTuple{N′,T}(coeffs[i] for i ∈ firstindex(coeffs):N)
     ImmutablePolynomial{T, X, N′}(cs)
@@ -75,7 +75,7 @@ end
 ## -- Tuple arguments
 function ImmutablePolynomial{T,X}(coeffs::Tuple)  where {T,X}
     N = findlast(!iszero, coeffs)
-    isnothing(N) && return zero(ImmutablePolynomial{T,X})
+    N == nothing && return zero(ImmutablePolynomial{T,X})
     ImmutablePolynomial{T,X,N}(NTuple{N,T}(coeffs[i] for i in 1:N))
 end
 
@@ -200,7 +200,7 @@ end
 function Base.:*(p1::ImmutablePolynomial{T,X,N}, p2::ImmutablePolynomial{S,Y,M}) where {T,X,N,S,Y,M}
     isconstant(p1) && return p2 * p1[0] 
     isconstant(p2) && return p1 * p2[0]
-    X != Y && throw(ArgumentError("Polynomials must have same variable"))
+    assert_same_variable(p1, p2)
     R = promote_type(S,T)
     cs = (p1.coeffs) ⊗ (p2.coeffs)
     if !iszero(cs[end])

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -66,7 +66,7 @@ function ImmutablePolynomial{T,X}(coeffs::AbstractVector{S})  where {T,X,S}
         @warn "ignoring the axis offset of the coefficient vector"
     end
     N = findlast(!iszero, coeffs)
-    N = nothing && return ImmutablePolynomial{R,X,0}(())
+    N == nothing && return ImmutablePolynomial{R,X,0}(())
     N′ = N + 1 - firstindex(coeffs)
     cs = NTuple{N′,T}(coeffs[i] for i ∈ firstindex(coeffs):N)
     ImmutablePolynomial{T, X, N′}(cs)

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -265,7 +265,7 @@ function Base.:+(p::ImmutablePolynomial{T,X,N}, c::S) where {T, X, N, S<:Number}
     R = promote_type(T,S)
 
     iszero(c) && return ImmutablePolynomial{R,X,N}(convert(NTuple{N,R},p.coeffs))
-    N == 0 && return ImmutablePolynomial{R,X,1}((c,))
+    N == 0 && return ImmutablePolynomial{R,X,1}(NTuple{1,R}(c))
     N == 1 && return ImmutablePolynomial((p[0]+c,), X)
     q = p + ImmutablePolynomial{S,X,1}((c,))
     return q

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -134,10 +134,12 @@ end
 # in common.jl these call chop! and truncate!
 function Base.chop(p::ImmutablePolynomial{T,X,N};
               rtol::Real = Base.rtoldefault(real(T)),
-              atol::Real = 0)  where {T,X,N}
+                   atol::Real = 0)  where {T,X,N}
+    N == 0 && return p
     cs = coeffs(p)
+    thresh = maximum(abs, cs) * rtol + atol
     for i in N:-1:1
-        if !isapprox(cs[i], zero(T), rtol=rtol, atol=atol)
+        if abs(cs[i]) > thresh
             return ImmutablePolynomial{T,X,i}(cs[1:i])
         end
     end
@@ -148,16 +150,13 @@ function Base.truncate(p::ImmutablePolynomial{T,X,N};
                        rtol::Real = Base.rtoldefault(real(T)),
                        atol::Real = 0)  where {T,X,N}
     q = chop(p, rtol=rtol, atol=atol)
-    iszero(q) && return  q
+    iszero(q) && return q
     cs = coeffs(q)
     thresh = maximum(abs,cs) * rtol + atol
     cs′ = map(c->abs(c) <= thresh ? zero(T) : c, cs)
     ImmutablePolynomial{T,X}(tuple(cs′...))
 end
 
-# no in-place chop! and truncate!
-chop!(p::ImmutablePolynomial; kwargs...) =  throw(MethodError("No `chop!` for the `ImmutablePolynomial` type. Use `chop`?")) 
-truncate!(p::ImmutablePolynomial; kwargs...) =  throw(MethodError("No `truncate!` for the `ImmutablePolynomial` type. Use `trunctate`?")) 
 
 ##
 ## --------------------

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -457,7 +457,7 @@ function Base.:+(p1::P1, p2::P2) where {T,X,P1<:LaurentPolynomial{T,X}, S,Y, P2<
         return q1
     end
 
-    X != Y && error("LaurentPolynomials must have same variable")
+    X != Y && throw(ArgumentError("LaurentPolynomials must have same variable"))
 
 
     m1,n1 = (extrema ∘ degreerange)(p1)
@@ -481,7 +481,7 @@ function Base.:*(p1::LaurentPolynomial{T,X}, p2::LaurentPolynomial{S,Y}) where {
     isconstant(p1) && return p2 * p1[0]
     isconstant(p2) && return p1 * p2[0]
 
-    X != Y && error("LaurentPolynomials must have same variable")
+    X != Y && throw(ArgumentError("LaurentPolynomials must have same variable"))
 
     R = promote_type(T,S)
 
@@ -546,7 +546,7 @@ end
 ##
 function derivative(p::P, order::Integer = 1) where {T, X, P<:LaurentPolynomial{T,X}}
 
-    order < 0 && error("Order of derivative must be non-negative")
+    order < 0 && throw(ArgumentError("Order of derivative must be non-negative"))
     order == 0 && return p
 
     hasnan(p) && return ⟒(P)(T[NaN], 0, X)

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -577,7 +577,7 @@ function integrate(p::P, k::S) where {T, X, P<: LaurentPolynomial{T, X}, S<:Numb
     Q = ⟒(P){R, X}
     
     if hasnan(p) || isnan(k)
-        return P([NaN], 0) # not Q([NaN])!! don't like XXX
+        return Q([NaN],0)
     end
 
 

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -457,8 +457,7 @@ function Base.:+(p1::P1, p2::P2) where {T,X,P1<:LaurentPolynomial{T,X}, S,Y, P2<
         return q1
     end
 
-    X != Y && throw(ArgumentError("LaurentPolynomials must have same variable"))
-
+    assert_same_variable(p1, p2)
 
     m1,n1 = (extrema ∘ degreerange)(p1)
     m2,n2 = (extrema ∘ degreerange)(p2)
@@ -481,7 +480,7 @@ function Base.:*(p1::LaurentPolynomial{T,X}, p2::LaurentPolynomial{S,Y}) where {
     isconstant(p1) && return p2 * p1[0]
     isconstant(p2) && return p1 * p2[0]
 
-    X != Y && throw(ArgumentError("LaurentPolynomials must have same variable"))
+    assert_same_variable(p1, p2)
 
     R = promote_type(T,S)
 
@@ -614,7 +613,7 @@ function Base.gcd(p::LaurentPolynomial{T,X}, q::LaurentPolynomial{T,Y}, args...;
 
     degree(p) == 0 && return iszero(p) ? q : one(q)
     degree(q) == 0 && return iszero(q) ? p : one(p)
-    check_same_variable(p,q) || throw(ArgumentError("p and q have different symbols"))
+    assert_same_variable(p,q) 
 
     pp, qq = convert(Polynomial, p), convert(Polynomial, q)
     u = gcd(pp, qq, args..., kwargs...)

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -444,56 +444,32 @@ end
 ##
 ## Poly + and  *
 ##
-function Base.:+(p1::P1, p2::P2) where {T,X,P1<:LaurentPolynomial{T,X}, S,Y, P2<:LaurentPolynomial{S,Y}}
+function Base.:+(p1::P, p2::P) where {T,X,P<:LaurentPolynomial{T,X}}
 
-    R = promote_type(T,S)
-    
-    if isconstant(p1)
-        i₁ = firstindex(p1)
-        q2 = LaurentPolynomial{R,Y}(p2.coeffs, p2.m[])
-        q2[i₁] += p1[i₁]
-        chop!(q2)
-        return q2
-    elseif isconstant(p2)
-        i₂ = firstindex(p2)
-        q1 = LaurentPolynomial{R,X}(p1.coeffs, p1.m[])        
-        q1[i₂] += p2[i₂]
-        chop!(q1)
-        return q1
-    end
-
-    assert_same_variable(p1, p2)
 
     m1,n1 = (extrema ∘ degreerange)(p1)
     m2,n2 = (extrema ∘ degreerange)(p2)
     m,n = min(m1,m2), max(n1, n2)
 
-    as = zeros(R, length(m:n))
+    as = zeros(T, length(m:n))
     for i in m:n
         as[1 + i-m] = p1[i] + p2[i]
     end
 
-    q = LaurentPolynomial{R,X}(as, m)
+    q = P(as, m)
     chop!(q)
 
     return q
 
 end
 
-function Base.:*(p1::LaurentPolynomial{T,X}, p2::LaurentPolynomial{S,Y}) where {T,X,S,Y}
-
-    isconstant(p1) && return p2 * p1[0]
-    isconstant(p2) && return p1 * p2[0]
-
-    assert_same_variable(p1, p2)
-
-    R = promote_type(T,S)
+function Base.:*(p1::P, p2::P) where {T,X,P<:LaurentPolynomial{T,X}}
 
     m1,n1 = (extrema ∘ degreerange)(p1)
     m2,n2 = (extrema ∘ degreerange)(p2)
     m,n = m1 + m2, n1+n2
 
-    as = zeros(R, length(m:n))
+    as = zeros(T, length(m:n))
     for i in eachindex(p1)
         p1ᵢ = p1[i]
         for j in eachindex(p2)
@@ -501,7 +477,7 @@ function Base.:*(p1::LaurentPolynomial{T,X}, p2::LaurentPolynomial{S,Y}) where {
         end
     end
 
-    p = LaurentPolynomial{R,X}(as, m)
+    p = P(as, m)
     chop!(p)
 
     return p

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -153,14 +153,14 @@ end
 ##
 ## generic functions
 ##
-function Base.extrema(p::LaurentPolynomial)
-    Base.depwarn("`extrema(::LaurentPolynomial)` is deprecated. Use `(firstindex(p), lastindex(p))`", :extrema)
-    (p.m[], p.n[])
-end
-function Base.range(p::LaurentPolynomial)
-    Base.depwarn("`range(::LaurentPolynomial)` is deprecated. Use `firstindex(p):lastindex(p)`", :range)
-    p.m[]:p.n[]
-end
+# function Base.extrema(p::LaurentPolynomial)
+#     Base.depwarn("`extrema(::LaurentPolynomial)` is deprecated. Use `(firstindex(p), lastindex(p))`", :extrema)
+#     (p.m[], p.n[])
+# end
+# function Base.range(p::LaurentPolynomial)
+#     Base.depwarn("`range(::LaurentPolynomial)` is deprecated. Use `firstindex(p):lastindex(p)`", :range)
+#     p.m[]:p.n[]
+# end
 
 function Base.inv(p::LaurentPolynomial{T, X}) where {T, X}
     m,n =  (extrema∘degreerange)(p)
@@ -184,14 +184,19 @@ Base.zero(::Type{LaurentPolynomial{T}},  var=Symbollike=:x) where {T} =  Laurent
 Base.zero(::Type{LaurentPolynomial},  var=Symbollike=:x) =  zero(LaurentPolynomial{Float64, Symbol(var)})
 Base.zero(p::P, var=Symbollike=:x) where {P  <: LaurentPolynomial} = zero(P, var)
 
-
-# get/set index. Work with  offset
-function Base.getindex(p::LaurentPolynomial{T}, idx::Int) where {T <: Number}
-    m,n = (extrema ∘ degreerange)(p)
-    i = idx - m + 1
-    (i < 1 || i > (n-m+1))  && return zero(T)
-    p.coeffs[i]
+function Base.getindex(p::LaurentPolynomial{T}, idx::Int) where {T}
+    m,M = firstindex(p), lastindex(p)
+    m <= idx <= M || return zero(T)
+    p.coeffs[idx-m+1]
 end
+
+# # get/set index. Work with  offset
+# function Base.getindex(p::LaurentPolynomial{T}, idx::Int) where {T <: Number}
+#     m,n = (extrema ∘ degreerange)(p)
+#     i = idx - m + 1
+#     (i < 1 || i > (n-m+1))  && return zero(T)
+#     p.coeffs[i]
+# end
 
 # extend if out of bounds
 function Base.setindex!(p::LaurentPolynomial{T}, value::Number, idx::Int) where {T}
@@ -432,7 +437,7 @@ end
 
 
 
-# scalar operattoinis
+# scalar operations
 # needed as standard-basis defn. assumes basis 1, x, x², ...
 function Base.:+(p::LaurentPolynomial{T,X}, c::S) where {T, X, S <: Number}
     R = promote_type(T,S)

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -153,14 +153,6 @@ end
 ##
 ## generic functions
 ##
-# function Base.extrema(p::LaurentPolynomial)
-#     Base.depwarn("`extrema(::LaurentPolynomial)` is deprecated. Use `(firstindex(p), lastindex(p))`", :extrema)
-#     (p.m[], p.n[])
-# end
-# function Base.range(p::LaurentPolynomial)
-#     Base.depwarn("`range(::LaurentPolynomial)` is deprecated. Use `firstindex(p):lastindex(p)`", :range)
-#     p.m[]:p.n[]
-# end
 
 function Base.inv(p::LaurentPolynomial{T, X}) where {T, X}
     m,n =  (extrema∘degreerange)(p)

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -304,7 +304,7 @@ Examples
 julia> using Polynomials;
 
 julia> z = variable(LaurentPolynomial, :z)
-LaurentPolynomial(z)
+LaurentPolynomial(1.0*z)
 
 julia> p = LaurentPolynomial([im, 1+im, 2 + im], -1, :z)
 LaurentPolynomial(im*z⁻¹ + 1 + im + (2 + im)z)

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -139,8 +139,7 @@ end
 Base.convert(::Type{P}, p::LaurentPolynomial) where {T, X, P<:LaurentPolynomial{T,X}} = P(p.coeffs, p.m[])
 function Base.convert(::Type{P}, p::LaurentPolynomial) where {P<:LaurentPolynomial}
     T = eltype(P)
-    v′ = _indeterminate(P)
-    X = v′ == nothing ? indeterminate(p) : v′
+    X = indeterminate(P,p)
     ⟒(P){T, X}(convert(Vector{T},p.coeffs), p.m[])
 end
 

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -212,7 +212,7 @@ degreerange(p::LaurentPolynomial) = firstindex(p):lastindex(p)
 
 _convert(p::P, as) where {T,X,P <: LaurentPolynomial{T,X}} = ⟒(P)(as, firstindex(p), X)
 
-## chop/truncation
+## chop!
 # trim  from *both* ends
 function chop!(p::LaurentPolynomial{T};
                rtol::Real = Base.rtoldefault(real(T)),
@@ -242,25 +242,6 @@ function chop!(p::LaurentPolynomial{T};
     p.m[], p.n[] = m, max(m,n)
 
     p
-
-end
-
-function truncate!(p::LaurentPolynomial{T};
-                  rtol::Real = Base.rtoldefault(real(T)),
-                  atol::Real = 0,) where {T}
-
-    max_coeff = maximum(abs, coeffs(p))
-    thresh = max_coeff * rtol + atol
-
-    for i in eachindex(p)
-        if abs(p[i]) <= thresh
-            p[i] = zero(T)
-        end
-    end
-
-    chop!(p)
-
-    return p
 
 end
 

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -383,7 +383,7 @@ end
 
 # evaluation uses `evalpoly`
 function evalpoly(x::S, p::LaurentPolynomial{T}) where {T,S}
-    xᵐ = (x/1)^firstindex(p) # make type stable
+    xᵐ = firstindex(p) < 0 ? inv(x)^(abs(firstindex(p))) : (x/1)^firstindex(p) # make type stable
     return EvalPoly.evalpoly(x, p.coeffs) * xᵐ
 end
 

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -451,6 +451,9 @@ end
 ##
 function Base.:+(p1::P, p2::P) where {T,X,P<:LaurentPolynomial{T,X}}
 
+    isconstant(p1) && return constantterm(p1) + p2
+    isconstant(p2) && return p1 + constantterm(p2)
+
 
     m1,n1 = (extrema ∘ degreerange)(p1)
     m2,n2 = (extrema ∘ degreerange)(p2)

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -44,6 +44,20 @@ Base.convert(P::Type{<:Poly}, p::Poly{T,X}) where {T<:Number,X} = Polynomials.co
 Base.eltype(P::Type{<:Poly{T,X}}) where {T, X} = P
 _eltype(::Type{<:Poly{T}}) where  {T} = T
 _eltype(::Type{Poly}) =  Float64
+
+# when interating over poly return monomials
+function Base.iterate(p::Poly, state=nothing)
+    i = 0
+    state == nothing && return (p[i]*one(p), i)
+    j = degree(p)
+    s = state + 1
+    i <= state < j && return (p[s]*Polynomials.basis(p,s), s)
+    return nothing
+end
+Base.collect(p::Poly) = [pᵢ for pᵢ ∈ p]
+
+
+
 Base.zero(P::Type{<:Poly},var=:x) = Poly(zeros(_eltype(P),0), var)
 Base.one(P::Type{<:Poly},var=:x) = Poly(ones(_eltype(P),1), var)
 function Polynomials.basis(P::Type{<:Poly}, k::Int, _var::Polynomials.SymbolLike=:x; var=_var) 

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -114,6 +114,22 @@ function Base.getproperty(p::Poly, nm::Symbol)
     return getfield(p, nm)
 end
 
+function Polynomials.integrate(p::P, k::S) where {T, X, P <: Poly{T, X}, S<:Number}
+
+    R = eltype((one(T)+one(S))/1)
+    Q = Poly{R,X}
+    if hasnan(p) || isnan(k)
+        return P([NaN]) # keep for Poly, not Q
+    end
+    n = length(p)
+    a2 = Vector{R}(undef, n + 1)
+    a2[1] = k
+    @inbounds for i in 1:n
+        a2[i + 1] = p[i - 1] / i
+    end
+    return Q(a2)
+end
+
 polyint(p::Poly, C = 0) = integrate(p, C)
 polyint(p::Poly, a, b) = integrate(p, a, b)
 polyint(p::AbstractPolynomial, args...)  = error("`polyint` is a legacy name for use with `Poly` objects only. Use `integrate(p,...)`.")

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -56,10 +56,13 @@ function Base.iterate(p::Poly, state=nothing)
 end
 Base.collect(p::Poly) = [pᵢ for pᵢ ∈ p]
 
-
-
-Base.zero(P::Type{<:Poly},var=:x) = Poly(zeros(_eltype(P),0), var)
-Base.one(P::Type{<:Poly},var=:x) = Poly(ones(_eltype(P),1), var)
+# need two here as `eltype(P)` is `_eltype(P)`.
+Base.zero(::Type{P}) where {P <: Poly} = Poly{_eltype(P), Polynomials.indeterminate(P)}([0])
+Base.zero(::Type{P},var::Polynomials.SymbolLike) where {P <: Poly} = Poly(zeros(_eltype(P),1), var)
+Base.one(::Type{P}) where {P <: Poly} = Poly{_eltype(P), Polynomials.indeterminate(P)}([1])
+Base.one(::Type{P},var::Polynomials.SymbolLike) where {P <: Poly} = Poly(ones(_eltype(P),1), var)
+Polynomials.variable(::Type{P}) where {P <: Poly} = Poly{_eltype(P), Polynomials.indeterminate(P)}([0,1])
+Polynomials.variable(::Type{P},var::Polynomials.SymbolLike) where {P <: Poly} = Poly(_eltype(P)[0,1], var)
 function Polynomials.basis(P::Type{<:Poly}, k::Int, _var::Polynomials.SymbolLike=:x; var=_var) 
     zs = zeros(Int, k+1)
     zs[end] = 1

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -1,6 +1,7 @@
 module PolyCompat
 
 using ..Polynomials
+indeterminate = Polynomials.indeterminate
 
 #=
 Compat support for old code. This will be opt-in by v1.0, through "using Polynomials.PolyCompat"
@@ -20,25 +21,27 @@ base. Call `using Polynomials.PolyCompat` to enable this module.
 """
 struct Poly{T <: Number,X} <: Polynomials.StandardBasisPolynomial{T,X}
     coeffs::Vector{T}
-    var::Symbol
     function Poly(a::AbstractVector{T}, var::Polynomials.SymbolLike = :x) where {T <: Number}
         # if a == [] we replace it with a = [0]
+        X = Symbol(var)
         if length(a) == 0
-            return new{T}(zeros(T, 1), Symbol(var))
+            return new{T,X}(zeros(T, 1))
         else
         # determine the last nonzero element and truncate a accordingly
             last_nz = findlast(!iszero, a)
             a_last = max(1, last_nz === nothing ? 0 : last_nz)
-            new{T}(a[1:a_last], Symbol(var))
+            new{T,X}(a[1:a_last])
         end
     end
 end
 
 Polynomials.@register Poly
 
-Base.convert(P::Type{<:Polynomial}, p::Poly{T}) where {T} = P(p.coeffs, p.var)
+Poly{T,X}(coeffs::AbstractVector{S}) where {T,X,S} = Poly(convert(Vector{T},coeffs), X)
 
-Base.eltype(P::Type{<:Poly}) = P
+Base.convert(P::Type{<:Polynomial}, p::Poly{T}) where {T} = Polynomial{eltype(P),indeterminate(P,p)}(p.coeffs)
+Base.convert(P::Type{<:Poly}, p::Poly{T,X}) where {T<:Number,X} = Polynomials.constructorof(P){_eltype(P),indeterminate(P,p)}(p.coeffs)
+Base.eltype(P::Type{<:Poly{T,X}}) where {T, X} = P
 _eltype(::Type{<:Poly{T}}) where  {T} = T
 _eltype(::Type{Poly}) =  Float64
 Base.zero(P::Type{<:Poly},var=:x) = Poly(zeros(_eltype(P),0), var)
@@ -46,7 +49,7 @@ Base.one(P::Type{<:Poly},var=:x) = Poly(ones(_eltype(P),1), var)
 function Polynomials.basis(P::Type{<:Poly}, k::Int, _var::Polynomials.SymbolLike=:x; var=_var) 
     zs = zeros(Int, k+1)
     zs[end] = 1
-    P(zs, var)
+    Polynomials.constructorof(P){_eltype(P), Symbol(var)}(zs)
 end
 
 function (p::Poly{T})(x::S) where {T,S}
@@ -61,14 +64,14 @@ end
 
 
 function Base.:+(p1::Poly, p2::Poly)
-    p1.var != p2.var && error("Polynomials must have same variable")
+    indeterminate(p1) != indeterminate(p2) && error("Polynomials must have same variable")
     n = max(length(p1), length(p2))
     c = [p1[i] + p2[i] for i = 0:n-1]
-    return Poly(c, p1.var)
+    return Poly(c, indeterminate(p1))
 end
 
 function Base.:*(p1::Poly{T}, p2::Poly{S}) where {T,S}
-    p1.var != p2.var && error("Polynomials must have same variable")
+    indeterminate(p1) != indeterminate(p2) && error("Polynomials must have same variable")
     n = length(p1) - 1
     m = length(p2) - 1
     R = promote_type(T, S)
@@ -76,7 +79,7 @@ function Base.:*(p1::Poly{T}, p2::Poly{S}) where {T,S}
     for i in 0:n, j in 0:m
         c[i + j + 1] += p1[i] * p2[j]
     end
-    return Poly(c, p1.var)
+    return Poly(c, indeterminate(p1))
 end
 
 

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -18,7 +18,7 @@ This type provides support for `poly`, `polyval`, `polyder`, and
 base. Call `using Polynomials.PolyCompat` to enable this module.
 
 """
-struct Poly{T <: Number} <: Polynomials.StandardBasisPolynomial{T}
+struct Poly{T <: Number,X} <: Polynomials.StandardBasisPolynomial{T,X}
     coeffs::Vector{T}
     var::Symbol
     function Poly(a::AbstractVector{T}, var::Polynomials.SymbolLike = :x) where {T <: Number}

--- a/src/polynomials/Polynomial.jl
+++ b/src/polynomials/Polynomial.jl
@@ -71,6 +71,20 @@ julia> p.(0:3)
 (p::Polynomial{T})(x::S) where {T,S} = evalpoly(x, coeffs(p))
 
 
+# scalar _,* faster  than standard-basis/common versions
+function Base.:+(p::P, c::S) where {T, X, P <: Polynomial{T, X}, S<:Number}
+     R = promote_type(T, S)
+     as = convert(Vector{R}, copy(coeffs(p)))
+     as[1] += c
+     return Polynomial{R, X}(as)
+end
+
+function Base.:*(p::P, c::S) where {T, X, P <: Polynomial{T,X} , S <: Number}
+    as = [aᵢ * c for aᵢ ∈ coeffs(p)]
+    Polynomial{promote_type(T,S),X}(as)
+end
+
+
    
 function Base.:+(p1::Polynomial{T}, p2::Polynomial{S}) where {T, S}
     n1, n2 = length(p1), length(p2)

--- a/src/polynomials/Polynomial.jl
+++ b/src/polynomials/Polynomial.jl
@@ -37,7 +37,7 @@ struct Polynomial{T <: Number, X} <: StandardBasisPolynomial{T, X}
             @warn "ignoring the axis offset of the coefficient vector"
         end
         N = findlast(!iszero, coeffs)
-        isnothing(N) && return new{T,X}(zeros(T,1))
+        N == nothing && return new{T,X}(zeros(T,1))
         cs = T[coeffs[i] for i ∈ firstindex(coeffs):N]
         new{T,X}(cs)
     end
@@ -92,8 +92,9 @@ end
 function Base.:+(p1::Polynomial{T}, p2::Polynomial{S}) where {T, S}
     isconstant(p1) && return p2 + p1[0]
     isconstant(p2) && return p1 + p2[0]
-    X, Y = indeterminate(p1), indeterminate(p2)
-    X != Y && throw(ArgumentError("Polynomials must have same variable"))
+    assert_same_variable(p1, p2)
+    X = indeterminate(p1)
+    
     n1, n2 = length(p1), length(p2)
     R = promote_type(T,S)
 
@@ -122,7 +123,7 @@ function Base.:*(p1::Polynomial{T}, p2::Polynomial{S}) where {T,S}
     X, Y = indeterminate(p1), indeterminate(p2)
     R = promote_type(T, S)
     if n > 0 && m > 0
-        X != Y && throw(ArgumentError("Polynomials must have same variable"))
+        assert_same_variable(p1, p2)
         c = zeros(R, m + n + 1)
         for i in 0:n, j in 0:m
             @inbounds c[i + j + 1] += p1[i] * p2[j]

--- a/src/polynomials/Polynomial.jl
+++ b/src/polynomials/Polynomial.jl
@@ -73,7 +73,7 @@ julia> p.(0:3)
 (p::Polynomial{T})(x::S) where {T,S} = evalpoly(x, coeffs(p))
 
 
-# scalar _,* faster  than standard-basis/common versions
+# scalar +,* faster  than standard-basis/common versions
 function Base.:+(p::P, c::S) where {T, X, P <: Polynomial{T, X}, S<:Number}
     R = promote_type(T, S)
     Q = Polynomial{R,X}
@@ -107,7 +107,7 @@ function Base.:+(p1::Polynomial{T}, p2::Polynomial{S}) where {T, S}
         c .= p2.coeffs
         for i in eachindex(p1.coeffs)
             c[i] += p1.coeffs[i]
-            end
+        end
     end
 
     Q = Polynomial{R,X}

--- a/src/polynomials/Polynomial.jl
+++ b/src/polynomials/Polynomial.jl
@@ -34,13 +34,12 @@ struct Polynomial{T <: Number, X} <: StandardBasisPolynomial{T, X}
     coeffs::Vector{T}
     function Polynomial{T, X}(coeffs::AbstractVector{T}) where {T <: Number, X}
         if Base.has_offset_axes(coeffs)
-          @warn "ignoring the axis offset of the coefficient vector"
+            throw(ArgumentError("The `Polynomial` constructor does not accept `OffsetArrays`. Try `LaurentPolynomial`."))
         end
         length(coeffs) == 0 && return new{T,X}(zeros(T, 1))
-        c = OffsetArrays.no_offset_view(coeffs) # ensure 1-based indexing
-        last_nz = findlast(!iszero, c)
+        last_nz = findlast(!iszero, coeffs)
         last = max(1, last_nz === nothing ? 0 : last_nz)
-        return new{T, X}(c[1:last])
+        return new{T, X}(coeffs[1:last])
     end
 end
 

--- a/src/polynomials/Polynomial.jl
+++ b/src/polynomials/Polynomial.jl
@@ -93,7 +93,7 @@ function Base.:+(p1::Polynomial{T}, p2::Polynomial{S}) where {T, S}
     isconstant(p1) && return p2 + p1[0]
     isconstant(p2) && return p1 + p2[0]
     X, Y = indeterminate(p1), indeterminate(p2)
-    X != Y && error("Polynomials must have same variable")
+    X != Y && throw(ArgumentError("Polynomials must have same variable"))
     n1, n2 = length(p1), length(p2)
     R = promote_type(T,S)
 
@@ -122,7 +122,7 @@ function Base.:*(p1::Polynomial{T}, p2::Polynomial{S}) where {T,S}
     X, Y = indeterminate(p1), indeterminate(p2)
     R = promote_type(T, S)
     if n > 0 && m > 0
-        X != Y && error("Polynomials must have same variable")
+        X != Y && throw(ArgumentError("Polynomials must have same variable"))
         c = zeros(R, m + n + 1)
         for i in 0:n, j in 0:m
             @inbounds c[i + j + 1] += p1[i] * p2[j]

--- a/src/polynomials/Polynomial.jl
+++ b/src/polynomials/Polynomial.jl
@@ -20,6 +20,8 @@ polynomials of different variables causes an error except those involving a cons
 
 # Examples
 ```jldoctest
+julia> using Polynomials
+
 julia> Polynomial([1, 0, 3, 4])
 Polynomial(1 + 3*x^2 + 4*x^3)
 
@@ -56,6 +58,8 @@ Evaluate the polynomial using [Horner's Method](https://en.wikipedia.org/wiki/Ho
 
 # Examples
 ```jldoctest
+julia> using Polynomials
+
 julia> p = Polynomial([1, 0, 3])
 Polynomial(1 + 3*x^2)
 

--- a/src/polynomials/Polynomial.jl
+++ b/src/polynomials/Polynomial.jl
@@ -112,10 +112,8 @@ function Base.:+(p1::P1, p2::P2) where {T,X, P1<:Polynomial{T,X},
     Q(Val(false), cs)
 end
         
-function Base.:*(p1::P, p2::P) where {T,X, P<:Polynomial{T,X}}
-
-    c = fastconv(p1.coeffs, p2.coeffs)
+function Base.:*(p::P, q::P) where {T,X, P<:Polynomial{T,X}}
+    c = fastconv(p.coeffs, q.coeffs)
     return iszero(c[end]) ? P(c) : P(Val(false), c)
-
 end
 

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -48,6 +48,9 @@ struct SparsePolynomial{T <: Number, X} <: StandardBasisPolynomial{T, X}
         end
         new{T, X}(c)
     end
+    function SparsePolynomial{T,X}(checked::Val{false}, coeffs::AbstractDict{Int, T}) where {T <: Number, X}
+        new{T,X}(convert(Dict{Int,S}, coeffs))
+    end
 end
 
 @register SparsePolynomial
@@ -61,17 +64,13 @@ function SparsePolynomial(coeffs::AbstractDict{Int, T}, var::SymbolLike=:x) wher
 end
 
 function SparsePolynomial{T,X}(coeffs::AbstractVector{S}) where {T <: Number, X, S}
-    firstindex(coeffs) >= 0 || throw(ArgumentError("Use the `LaurentPolynomial` type for arrays with a negative first index"))
 
     if Base.has_offset_axes(coeffs)
-        # throw(ArgumentError("The `SparsePolynomial` constructor does not accept `OffsetArrays`. Try `LaurentPolynomial`."))
-
         @warn "ignoring the axis offset of the coefficient vector"
-        coeffs = OffsetArrays.no_offset_view(coeffs) 
     end
 
-    c = OffsetArrays.no_offset_view(coeffs) # ensure 1-based indexing
-    p = Dict{Int,T}(i - 1 => v for (i,v) in pairs(c))
+    offset = firstindex(coeffs)
+    p = Dict{Int,T}(k - offset => v for (k,v) ∈ pairs(coeffs))
     return SparsePolynomial{T,X}(p)
 end
 

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -103,7 +103,7 @@ end
 
 # return coeffs as  a vector
 # use p.coeffs to get Dictionary
-function  coeffs(p::SparsePolynomial{T})  where {T}
+function coeffs(p::SparsePolynomial{T})  where {T}
 
     n = degree(p)
     cs = zeros(T, n+1)

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -212,7 +212,7 @@ function Base.:+(p1::SparsePolynomial{T,X}, p2::SparsePolynomial{S,Y}) where {T,
     isconstant(p1) && return p2 + p1[0]
     isconstant(p2) && return p1 + p2[0]
 
-    X != Y && throw(ArgumentError("SparsePolynomials must have same variable"))
+    assert_same_variable(p1, p2)
 
     R = promote_type(T,S)
     p = zero(SparsePolynomial{R,X})
@@ -253,7 +253,7 @@ function Base.:*(p1::SparsePolynomial{T,X}, p2::SparsePolynomial{S,Y}) where {T,
 
     isconstant(p1) && return p2 * p1[0]
     isconstant(p2) && return p1 * p2[0]
-    X != Y && throw(ArgumentError("SparsePolynomials must have same variable"))
+    assert_same_variable(p1, p2)
 
     R = promote_type(T,S)
     P = SparsePolynomial

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -306,16 +306,16 @@ function derivative(p::SparsePolynomial{T,X}, order::Integer = 1) where {T,X}
 end
 
 
-function integrate(p::P, k::S) where {T, X, P<:SparsePolynomial{T,X}, S<:Number}
+function integrate(p::P) where {T, X, P<:SparsePolynomial{T,X}}
     
-    R = eltype((one(T)+one(S))/1)
+    R = eltype(one(T)/1)
     Q = SparsePolynomial{R,X}
 
-    if hasnan(p) || isnan(k)
+    if hasnan(p)
         return Q(Dict(0 => NaN))
     end
 
-    ∫p = Q(R(k))
+    ∫p = zero(Q)
     for k in eachindex(p)
         ∫p[k + 1] = p[k] / (k+1)
     end
@@ -323,3 +323,4 @@ function integrate(p::P, k::S) where {T, X, P<:SparsePolynomial{T,X}, S<:Number}
     return ∫p
 
 end
+

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -141,6 +141,7 @@ function Base.iterate(v::PolynomialKeys{SparsePolynomial{T,X}}, state...) where 
     y == nothing && return nothing
     return (y[1][1], y[2])
 end
+
 function Base.iterate(v::PolynomialValues{SparsePolynomial{T,X}}, state...) where {T,X}
     y = iterate(v.p.coeffs, state...)
     y == nothing && return nothing
@@ -148,39 +149,6 @@ function Base.iterate(v::PolynomialValues{SparsePolynomial{T,X}}, state...) wher
 end
 
 
-# only from tail
-function chop!(p::SparsePolynomial{T};
-               rtol::Real = Base.rtoldefault(real(T)),
-               atol::Real = 0,) where {T}
-
-    for k in sort(collect(keys(p.coeffs)), by=x->x[1], rev=true)
-        if isapprox(p[k], zero(T); rtol = rtol, atol = atol)
-            pop!(p.coeffs, k)
-        else
-            return p
-        end
-    end
-    
-    return p
-    
-end
-
-function truncate!(p::SparsePolynomial{T};
-                   rtol::Real = Base.rtoldefault(real(T)),
-                   atol::Real = 0,) where {T}
-    
-    max_coeff = maximum(abs, coeffs(p))
-    thresh = max_coeff * rtol + atol
-
-    for (k,val) in  p.coeffs
-        if abs(val) <= thresh
-            pop!(p.coeffs,k)
-        end
-    end
-    
-    return p
-    
-end
 
 ##
 ## ----

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -219,14 +219,12 @@ function Base.:+(p::SparsePolynomial{T,X}, c::S) where {T, X, S <: Number}
 
     R = promote_type(T,S)
     P = SparsePolynomial
-    
-    q = zero(P{R,X})
-    for k in eachindex(p)
-        @inbounds q[k] = R(p[k])
-    end
-    q[0] = q[0] + c
 
-    return q
+    D = Dict{Int, R}(kv for kv ∈ p.coeffs)
+    D[0] = get(D,0,zero(R)) + c
+
+    return SparsePolynomial{R,X}(D)
+    
 end
 
 function Base.:*(p1::SparsePolynomial{T,X}, p2::SparsePolynomial{S,Y}) where {T,X,S,Y}

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -207,15 +207,9 @@ end
 
 
    
-function Base.:+(p1::SparsePolynomial{T,X}, p2::SparsePolynomial{S,Y}) where {T, X, S, Y}
+function Base.:+(p1::P, p2::P) where {T, X, P<:SparsePolynomial{T,X}}
 
-    isconstant(p1) && return p2 + p1[0]
-    isconstant(p2) && return p1 + p2[0]
-
-    assert_same_variable(p1, p2)
-
-    R = promote_type(T,S)
-    p = zero(SparsePolynomial{R,X})
+    p = zero(SparsePolynomial{T,X})
 
     # this allocates in the union
 #    for i in union(eachindex(p1), eachindex(p2)) 
@@ -249,16 +243,9 @@ function Base.:+(p::SparsePolynomial{T,X}, c::S) where {T, X, S <: Number}
     
 end
 
-function Base.:*(p1::SparsePolynomial{T,X}, p2::SparsePolynomial{S,Y}) where {T,X,S,Y}
-
-    isconstant(p1) && return p2 * p1[0]
-    isconstant(p2) && return p1 * p2[0]
-    assert_same_variable(p1, p2)
-
-    R = promote_type(T,S)
-    P = SparsePolynomial
+function Base.:*(p1::P, p2::P) where {T,X,P<:SparsePolynomial{T,X}}
     
-    p  = zero(P{R, X})
+    p  = zero(P)
     for i in eachindex(p1)
         p1ᵢ = p1[i]
         for j in eachindex(p2)

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -224,7 +224,7 @@ function Base.:+(p::SparsePolynomial{T,X}, c::S) where {T, X, S <: Number}
     
 end
 
-# Implement over fallback. A bit faster for T != S
+# Implement over fallback. A bit faster as it covers T != S
 function Base.:+(p1::P1, p2::P2) where {T,X, P1<:SparsePolynomial{T,X},
                                         S,   P2<:SparsePolynomial{S,X}}
 

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -313,14 +313,14 @@ function integrate(p::P, k::S) where {T, X, P<:SparsePolynomial{T,X}, S<:Number}
     Q = SparsePolynomial{R,X}
 
     if hasnan(p) || isnan(k)
-        return P(Dict(0 => NaN)) # not Q(NaN)!! don't like XXX
+        return Q(Dict(0 => NaN))
     end
 
     ∫p = Q(R(k))
     for k in eachindex(p)
         ∫p[k + 1] = p[k] / (k+1)
     end
-    
+
     return ∫p
-    
+
 end

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -95,6 +95,10 @@ function isconstant(p::SparsePolynomial)
     return true
 end
 
+function basis(P::Type{<:SparsePolynomial}, n::Int)
+    T,X = eltype(P), indeterminate(P)
+    SparsePolynomial{T,X}(Dict(n=>one(T)))
+end
 
 # return coeffs as  a vector
 # use p.coeffs to get Dictionary

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -95,11 +95,6 @@ function isconstant(p::SparsePolynomial)
     return true
 end
 
-function basis(P::Type{<:SparsePolynomial}, n::Int, var::SymbolLike=:x) 
-    T = eltype(P)
-    X = Symbol(var)
-    SparsePolynomial{T,X}(Dict(n=>one(T)))
-end
 
 # return coeffs as  a vector
 # use p.coeffs to get Dictionary

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -212,7 +212,7 @@ function Base.:+(p1::SparsePolynomial{T,X}, p2::SparsePolynomial{S,Y}) where {T,
     isconstant(p1) && return p2 + p1[0]
     isconstant(p2) && return p1 + p2[0]
 
-    X != Y && error("SparsePolynomials must have same variable")
+    X != Y && throw(ArgumentError("SparsePolynomials must have same variable"))
 
     R = promote_type(T,S)
     p = zero(SparsePolynomial{R,X})
@@ -253,7 +253,7 @@ function Base.:*(p1::SparsePolynomial{T,X}, p2::SparsePolynomial{S,Y}) where {T,
 
     isconstant(p1) && return p2 * p1[0]
     isconstant(p2) && return p1 * p2[0]
-    X != Y && error("SparsePolynomials must have same variable")
+    X != Y && throw(ArgumentError("SparsePolynomials must have same variable"))
 
     R = promote_type(T,S)
     P = SparsePolynomial
@@ -286,7 +286,7 @@ end
 
 function derivative(p::SparsePolynomial{T,X}, order::Integer = 1) where {T,X}
     
-    order < 0 && error("Order of derivative must be non-negative")
+    order < 0 && throw(ArgumentError("Order of derivative must be non-negative"))
     order == 0 && return p
 
     R = eltype(one(T)*1)

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -83,8 +83,8 @@ function Base.convert(P::Type{<:Polynomial}, q::SparsePolynomial)
 end
 
 function Base.convert(P::Type{<:SparsePolynomial}, q::StandardBasisPolynomial{T}) where {T}
-    R = promote(eltype(P), T)
-    ⟒(P){R}(coeffs(q), indeterminate(q))
+    R = promote_type(eltype(P), T)
+    ⟒(P){R,indeterminate(P,q)}(coeffs(q))
 end
 
 ## changes to common

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -135,6 +135,20 @@ Base.firstindex(p::SparsePolynomial) = sort(collect(keys(p.coeffs)), by=x->x[1])
 Base.lastindex(p::SparsePolynomial) = sort(collect(keys(p.coeffs)), by=x->x[1])[end]
 Base.eachindex(p::SparsePolynomial) = sort(collect(keys(p.coeffs)), by=x->x[1])
 
+# pairs iterates only over non-zero
+# inherits order for underlying dictionary
+function Base.iterate(v::PolynomialKeys{SparsePolynomial{T,X}}, state...) where {T,X}
+    y = iterate(v.p.coeffs, state...)
+    y == nothing && return nothing
+    return (y[1][1], y[2])
+end
+function Base.iterate(v::PolynomialValues{SparsePolynomial{T,X}}, state...) where {T,X}
+    y = iterate(v.p.coeffs, state...)
+    y == nothing && return nothing
+    return (y[1][2], y[2])
+end
+
+
 # only from tail
 function chop!(p::SparsePolynomial{T};
                rtol::Real = Base.rtoldefault(real(T)),

--- a/src/polynomials/ngcd.jl
+++ b/src/polynomials/ngcd.jl
@@ -24,7 +24,7 @@ function ngcd(p::P, q::Q, args...;kwargs...) where {T, S, P<:StandardBasisPolyno
     ps, qs = [p′[i] for i in eachindex(p′)], [q′[i] for i in eachindex(q′)] # need vectors, want copy
     u,v,w,Θ,κ = NGCD.ngcd(ps, qs, args...; kwargs...)
     P′ = ⟒(typeof(p′))
-    (u=P′(u, p.var), v=P′(v, p.var), w = P′(w, p.var), θ=Θ, κ=κ)
+    (u=P′(u, indeterminate(p)), v=P′(v, indeterminate(p)), w = P′(w, indeterminate(p)), θ=Θ, κ=κ)
     
 end
 

--- a/src/polynomials/ngcd.jl
+++ b/src/polynomials/ngcd.jl
@@ -13,7 +13,7 @@ function ngcd(p::P, q::Q, args...;kwargs...) where {T, S, P<:StandardBasisPolyno
     degree(p) == 0 && return (u=one(q), v=p, w=zero(q), θ=NaN, κ=NaN)
     degree(q) < 0  && return (u=one(q), v=p, w=zero(q), θ=NaN, κ=NaN)
     degree(q) == 0 && return (u=one(p), v=p, w=q,       θ=NaN, κ=NaN)
-    check_same_variable(p,q) || throw(ArgumentError("Mis-matched variables"))
+    assert_same_variable(p,q) 
 
     p′,q′ = promote(p,q)
     

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -99,7 +99,7 @@ end
 
 function Base.divrem(num::P, den::Q) where {T, P <: StandardBasisPolynomial{T}, S, Q <: StandardBasisPolynomial{S}}
 
-    check_same_variable(num, den) || throw(ArgumentError("Polynomials must have same variable"))
+    assert_same_variable(num, den) 
     X = indeterminate(num)
 
 

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -17,6 +17,7 @@ end
 
 # allows  broadcast  issue #209
 evalpoly(x, p::StandardBasisPolynomial) = p(x)
+constantterm(p::StandardBasisPolynomial) = p.coeffs[1]
 
 domain(::Type{<:StandardBasisPolynomial}) = Interval(-Inf, Inf)
 mapdomain(::Type{<:StandardBasisPolynomial}, x::AbstractArray) = x

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -55,8 +55,13 @@ function Base.convert(P::Type{<:StandardBasisPolynomial}, q::StandardBasisPolyno
     end
 end
 
-function variable(::Type{P}, var::SymbolLike) where {P <: StandardBasisPolynomial}
-    ⟒(P){eltype(P), indeterminate(P,Symbol(var))}([0, 1])
+function Base.one(::Type{P}) where {P<:StandardBasisPolynomial}
+    T,X = eltype(P), indeterminate(P)
+    ⟒(P){T,X}(ones(T,1))
+end
+function variable(::Type{P}) where {P<:StandardBasisPolynomial}
+    T,X = eltype(P), indeterminate(P)
+    ⟒(P){T,X}([zero(T),one(T)])
 end
 
 ## multiplication algorithms for computing p * q.

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -30,7 +30,7 @@ Base.convert(P::Type{<:StandardBasisPolynomial}, q::StandardBasisPolynomial) = i
 
 #Base.values(p::StandardBasisPolynomial) = values(p.coeffs)
 
-variable(::Type{P}, var::SymbolLike = :x) where {P <: StandardBasisPolynomial} = P([0, 1], var)
+variable(::Type{P}, var::SymbolLike = :x) where {P <: StandardBasisPolynomial} = ⟒(P){eltype(P),Symbol(var)}([0, 1])
 
 function fromroots(P::Type{<:StandardBasisPolynomial}, r::AbstractVector{T}; var::SymbolLike = :x) where {T <: Number}
     n = length(r)

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -82,9 +82,11 @@ function integrate(p::P, k::S) where {T, X, P <: StandardBasisPolynomial{T, X}, 
 
     R = eltype((one(T)+one(S))/1)
     Q = ⟒(P){R,X}    
+
     if hasnan(p) || isnan(k)
-        return ⟒(P){T,X}([NaN]) # XXX
+        return Q([NaN])
     end
+
     n = length(p)
     a2 = Vector{R}(undef, n + 1)
     a2[1] = k

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -56,7 +56,7 @@ end
 
 
 function derivative(p::P, order::Integer = 1) where {T, X, P <: StandardBasisPolynomial{T, X}}
-    order < 0 && error("Order of derivative must be non-negative")
+    order < 0 && throw(ArgumentError("Order of derivative must be non-negative"))
 
     # we avoid usage like Base.promote_op(*, T, Int) here, say, as
     # Base.promote_op(*, Rational, Int) is Any, not Rational in analogy to
@@ -99,7 +99,7 @@ end
 
 function Base.divrem(num::P, den::Q) where {T, P <: StandardBasisPolynomial{T}, S, Q <: StandardBasisPolynomial{S}}
 
-    check_same_variable(num, den) || error("Polynomials must have same variable")
+    check_same_variable(num, den) || throw(ArgumentError("Polynomials must have same variable"))
     X = indeterminate(num)
 
 
@@ -256,7 +256,7 @@ Base.gcd(::Val{:numerical}, p, q, args...; kwargs...) = ngcd(p,q, args...; kwarg
 
 function companion(p::P) where {T, P <: StandardBasisPolynomial{T}}
     d = length(p) - 1
-    d < 1 && error("Series must have degree greater than 1")
+    d < 1 && throw(ArgumentError("Series must have degree greater than 1"))
     d == 1 && return diagm(0 => [-p[0] / p[1]])
 
 

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -28,7 +28,7 @@ isconstant(p::StandardBasisPolynomial) = degree(p) <= 0
 
 Base.convert(P::Type{<:StandardBasisPolynomial}, q::StandardBasisPolynomial) = isa(q, P) ? q : P([q[i] for i in 0:degree(q)], indeterminate(q))
 
-Base.values(p::StandardBasisPolynomial) = values(p.coeffs)
+#Base.values(p::StandardBasisPolynomial) = values(p.coeffs)
 
 variable(::Type{P}, var::SymbolLike = :x) where {P <: StandardBasisPolynomial} = P([0, 1], var)
 

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -26,11 +26,19 @@ mapdomain(::Type{<:StandardBasisPolynomial}, x::AbstractArray) = x
 ## generic test if polynomial `p` is a constant
 isconstant(p::StandardBasisPolynomial) = degree(p) <= 0
 
-Base.convert(P::Type{<:StandardBasisPolynomial}, q::StandardBasisPolynomial) = isa(q, P) ? q : P([q[i] for i in 0:degree(q)], indeterminate(q))
+function Base.convert(P::Type{<:StandardBasisPolynomial}, q::StandardBasisPolynomial)
+    if isa(q, P)
+        return q
+    else
+        T = _eltype(P,q)
+        X = indeterminate(P,q)
+        return ⟒(P){T,X}([q[i] for i in 0:degree(q)])
+    end
+end
 
-#Base.values(p::StandardBasisPolynomial) = values(p.coeffs)
-
-variable(::Type{P}, var::SymbolLike = :x) where {P <: StandardBasisPolynomial} = ⟒(P){eltype(P),Symbol(var)}([0, 1])
+function variable(::Type{P}, var::SymbolLike) where {P <: StandardBasisPolynomial}
+    ⟒(P){eltype(P), indeterminate(P,Symbol(var))}([0, 1])
+end
 
 function fromroots(P::Type{<:StandardBasisPolynomial}, r::AbstractVector{T}; var::SymbolLike = :x) where {T <: Number}
     n = length(r)

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -1,7 +1,5 @@
 abstract type StandardBasisPolynomial{T,X} <: AbstractPolynomial{T,X} end
 
-
-
 function showterm(io::IO, ::Type{<:StandardBasisPolynomial}, pj::T, var, j, first::Bool, mimetype) where {T}
 
     if iszero(pj) return false end
@@ -85,25 +83,22 @@ function derivative(p::P, order::Integer = 1) where {T, X, P <: StandardBasisPol
     Q(a2)
 end
 
-
-function integrate(p::P, k::S) where {T, X, P <: StandardBasisPolynomial{T, X}, S<:Number}
-
-    R = eltype((one(T)+one(S))/1)
+function integrate(p::P) where {T, X, P <: StandardBasisPolynomial{T, X}}
+    R = eltype(one(T)/1)
     Q = ⟒(P){R,X}    
 
-    if hasnan(p) || isnan(k)
+    if hasnan(p)
         return Q([NaN])
     end
 
     n = length(p)
     a2 = Vector{R}(undef, n + 1)
-    a2[1] = k
+    a2[1] = zero(R)
     @inbounds for i in 1:n
         a2[i + 1] = p[i - 1] / i
     end
     return Q(a2)
 end
-
 
 function Base.divrem(num::P, den::Q) where {T, P <: StandardBasisPolynomial{T}, S, Q <: StandardBasisPolynomial{S}}
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -93,7 +93,7 @@ end
 ###
 
 """
-    printpoly(io::IO, p::AbstractPolynomial, mimetype = MIME"text/plain"(); descending_powers=false, offset::Int=0, var=p.var, compact=false, mulsymbol="*")
+    printpoly(io::IO, p::AbstractPolynomial, mimetype = MIME"text/plain"(); descending_powers=false, offset::Int=0, var=var(p), compact=false, mulsymbol="*")
 
 Print a human-readable representation of the polynomial `p` to `io`. The MIME
 types "text/plain" (default), "text/latex", and "text/html" are supported. By
@@ -133,7 +133,7 @@ julia> printpoly(stdout, map(x -> round(x, digits=12), p))  # more control on ro
 ```
 """
 function printpoly(io::IO, p::P, mimetype=MIME"text/plain"();
-                   descending_powers=false, offset::Int=0, var=p.var,
+                   descending_powers=false, offset::Int=0, var=var(p),
                    compact=false, mulsymbol="*") where {T,P<:AbstractPolynomial{T}}
     first = true
     printed_anything = false

--- a/src/show.jl
+++ b/src/show.jl
@@ -93,7 +93,7 @@ end
 ###
 
 """
-    printpoly(io::IO, p::AbstractPolynomial, mimetype = MIME"text/plain"(); descending_powers=false, offset::Int=0, var=var(p), compact=false, mulsymbol="*")
+    printpoly(io::IO, p::AbstractPolynomial, mimetype = MIME"text/plain"(); descending_powers=false, offset::Int=0, var=indeterminate(p), compact=false, mulsymbol="*")
 
 Print a human-readable representation of the polynomial `p` to `io`. The MIME
 types "text/plain" (default), "text/latex", and "text/html" are supported. By
@@ -133,7 +133,7 @@ julia> printpoly(stdout, map(x -> round(x, digits=12), p))  # more control on ro
 ```
 """
 function printpoly(io::IO, p::P, mimetype=MIME"text/plain"();
-                   descending_powers=false, offset::Int=0, var=var(p),
+                   descending_powers=false, offset::Int=0, var=indeterminate(p),
                    compact=false, mulsymbol="*") where {T,P<:AbstractPolynomial{T}}
     first = true
     printed_anything = false

--- a/test/ChebyshevT.jl
+++ b/test/ChebyshevT.jl
@@ -91,8 +91,8 @@ end
 @testset "Companion" begin
     c_null = ChebyshevT(Int[])
     c_1 = ChebyshevT([1])
-    @test_throws ErrorException companion(c_null)
-    @test_throws ErrorException companion(c_1)
+    @test_throws ArgumentError companion(c_null)
+    @test_throws ArgumentError companion(c_1)
     for i in 1:5
         coef = vcat(zeros(i), 1)
         c = ChebyshevT(coef)

--- a/test/ChebyshevT.jl
+++ b/test/ChebyshevT.jl
@@ -8,7 +8,7 @@
     @test p.coeffs == coeff
     @test coeffs(p) == coeff
     @test degree(p) == length(coeff) - 1
-    @test p.var == :x
+    @test Polynomials.indeterminate(p) == :x
     @test length(p) == length(coeff)
     @test size(p) == size(coeff)
     @test size(p, 1) == size(coeff, 1)

--- a/test/Poly.jl
+++ b/test/Poly.jl
@@ -88,7 +88,7 @@ sprint(show, pNULL)
 @test polyder(pR) == Poly([-2//1,2//1])
 @test polyder(p3) == Poly([2,2])
 @test polyder(p1) == polyder(p0) == polyder(pNULL) == pNULL
-@test_throws ErrorException polyder(pR, -1)
+@test_throws ArgumentError polyder(pR, -1)
 @test polyint(pNULL,1) == p1
 @test polyint(Poly(Rational[1,2,3])) == Poly(Rational[0, 1, 1, 1])
 @test polyint(p2, 0, 2) == 4.0
@@ -148,8 +148,8 @@ pS3 = Poly([1, 2, 3, 4, 5], :s)
 @test_throws ErrorException pS1 + pX
 @test_throws ErrorException pS1 - pX
 @test_throws ErrorException pS1 * pX
-@test_throws ErrorException pS1 ÷ pX
-@test_throws ErrorException pS1 % pX
+@test_throws ArgumentError pS1 ÷ pX
+@test_throws ArgumentError pS1 % pX
 
 #Testing copying.
 pcpy1 = Poly([1,2,3,4,5], :y)
@@ -357,7 +357,7 @@ p2s = Poly([1], :s)
 @test p1s ≠ p1x
 @test p1s ≠ p2s
 
-@test_throws ErrorException p1s ≈ p1x
+@test_throws ArgumentError p1s ≈ p1x
 @test p1s ≉ p2s
 @test p1s ≈ Poly([1,2.], :s)
 

--- a/test/Poly.jl
+++ b/test/Poly.jl
@@ -75,7 +75,7 @@ sprint(show, pNULL)
 @test pNULL^3 == pNULL
 @test pNULL*pNULL == pNULL
 
-@test map(degree, [pNULL,p0,p1,p2,p3,p4,p5,pN,pR,p1000]) == [-1,-1,0,1,2,3,4,4,2,999]
+@test map(degree, (pNULL,p0,p1,p2,p3,p4,p5,pN,pR,p1000)) == (-1,-1,0,1,2,3,4,4,2,999)
 
 @test polyval(poly(Int[]), 2.) == 1.
 @test polyval(pN, -.125) == 276.9609375
@@ -227,13 +227,13 @@ p1  = Poly([1, 2])
 p2  = Poly([3, 1.])
 p   = [p1, p2]
 q   = [3, p1]
-@test isa(q,Vector{Poly{Int}})
+@test isa(q,Vector{Poly{Int,:x}})
 psum  = p .+ 3
 pprod = p .* 3
 pmin  = p .- 3
-@test isa(psum, Vector{Poly{Float64}})
-@test isa(pprod,Vector{Poly{Float64}})
-@test isa(pmin, Vector{Poly{Float64}})
+@test isa(psum, Vector{Poly{Float64,:x}})
+@test isa(pprod,Vector{Poly{Float64,:x}})
+@test isa(pmin, Vector{Poly{Float64,:x}})
 
 ## getindex with ranges #43
 p1 = Poly([4,5,6])
@@ -344,9 +344,9 @@ pint  = polyint(p, Complex(0.))
 
 ## proper conversions in arithmetic with different element-types #94
 p = Poly([0,one(Float64)])
-@test Poly{Complex{Float64}} == typeof(p+1im)
-@test Poly{Complex{Float64}} == typeof(1im-p)
-@test Poly{Complex{Float64}} == typeof(p*1im)
+@test Poly{Complex{Float64},:x} == typeof(p+1im)
+@test Poly{Complex{Float64},:x} == typeof(1im-p)
+@test Poly{Complex{Float64},:x} == typeof(p*1im)
 
 ## comparison between `Number`s and `Poly`s
 p1s = Poly([1,2], :s)
@@ -391,8 +391,8 @@ end
 # was to direct `collect{T}(p::Poly{T})` to `collect(Poly{T}, p)`.
 
 @test eltype(p1) == Int
-@test eltype(collect(p1)) == Poly{Int}
-@test eltype(collect(Poly{Float64}, p1)) == Poly{Float64}
+@test eltype(collect(p1)) == Poly{Int,:x}
+@test eltype(collect(Poly{Float64,:x}, p1)) == Poly{Float64,:x}
 @test_throws InexactError collect(Poly{Int}, Poly([1.2]))
 
 @test length(collect(p1)) == degree(p1)+1
@@ -450,8 +450,8 @@ end
 end
 
 @testset "`isintegral`" begin
-    x = Polynomial([1 // 1, Int8(2) + 0im, 3.0, Int16(4) + 0im])
-    y = Polynomial([1 // 2, Int8(2) + 0im, 3.0, Int16(4) + 0im])
+    x = Poly([1 // 1, Int8(2) + 0im, 3.0, Int16(4) + 0im])
+    y = Poly([1 // 2, Int8(2) + 0im, 3.0, Int16(4) + 0im])
     @test isintegral(x) === true
     @test isintegral(y) === false
     @test convert(Polynomial{Int}, x) == Polynomial([1, 2, 3, 4])

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -35,7 +35,7 @@ isimmutable(::Type{<:ImmutablePolynomial}) = true
         p = P(coeff)
         @test coeffs(p) ==ᵗ⁰ coeff
         @test degree(p) == length(coeff) - 1
-        @test Polynomials.var(p) == :x
+        @test Polynomials.indeterminate(p) == :x
         P == Polynomial && @test length(p) == length(coeff)
         P == Polynomial && @test size(p) == size(coeff)
         P == Polynomial && @test size(p, 1) == size(coeff, 1)
@@ -124,31 +124,37 @@ Base.getindex(z::ZVector, I::Int) = parent(z)[I + z.offset]
         @test Polynomials.isconstant(P(1))
         @test !Polynomials.isconstant(variable(P))
     end
+end
 
-    @testset "OffsetVector" begin
-        as = ones(3:4)
-        bs = parent(as)
-
-        # LaurentPolynomial accepts OffsetArrays; others do not and throw an ArgumentError
-        @test LaurentPolynomial(as) == LaurentPolynomial(bs, 3)
-
-        for P in Ps
-            P == LaurentPolynomial && continue
-            @test_throws ArgumentError P(as) 
-            @test P{eltype(as)}(as) == P{eltype(as)}(bs)
-        end
+@testset "OffsetVector" begin
+    as = ones(3:4)
+    bs = parent(as)
+    
+    # LaurentPolynomial accepts OffsetArrays; others do not and throw an ArgumentError
+    @test LaurentPolynomial(as) == LaurentPolynomial(bs, 3)
+    
+    for P in Ps
+        P == LaurentPolynomial && continue
+        @test P(as) == P(bs)
+        @test P{eltype(as)}(as) == P{eltype(as)}(bs)
+#        P == LaurentPolynomial && continue # XXX move to this
+#        @test_throws ArgumentError P(as) 
+#        @test P{eltype(as)}(as) == P{eltype(as)}(bs)
+    end
         
-        a = [1,1]
-        b = OffsetVector(a, axes(a))
-        c = ZVector(a)
-        d = ZVector(b)
-        for P in Ps
-            if P == LaurentPolynomial && continue
+    a = [1,1]
+    b = OffsetVector(a, axes(a))
+    c = ZVector(a)
+    d = ZVector(b)
+    for P in Ps
+        if P == LaurentPolynomial && continue
             @test P(a) == P(b) == P(c) == P(d)
         end
-
-        @test ImmutablePolynomial{eltype(as), length(as)}(as) == ImmutablePolynomial(bs)
+        
     end
+
+    @test ImmutablePolynomial{eltype(as)}(as) == ImmutablePolynomial(bs)
+    
 end
 
 
@@ -639,8 +645,8 @@ end
             @test q isa Vector{typeof(p1)}
             @test p isa Vector{typeof(p2)}
         else
-            @test q isa Vector{P{eltype(p1)}} # ImmutablePolynomial{Int64,N} where {N}, different  Ns
-            @test p isa Vector{P{eltype(p2)}} # ImmutablePolynomial{Int64,N} where {N}, different  Ns
+            @test q isa Vector{P{eltype(p1),:x}} # ImmutablePolynomial{Int64,N} where {N}, different  Ns
+            @test p isa Vector{P{eltype(p2),:x}} # ImmutablePolynomial{Int64,N} where {N}, different  Ns
         end
 
 

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -353,7 +353,7 @@ end
         fit(P, xx, yy, 2)
 
         # issue #214 --  should error
-        @test_throws MethodError fit(Polynomial, rand(2,2), rand(2,2))
+        @test_throws ArgumentError fit(Polynomial, rand(2,2), rand(2,2))
 
         # issue #268 -- inexacterror
         @test fit(P, 1:4, 1:4, var=:x) ≈ variable(P{Float64}, :x)

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -130,16 +130,18 @@ end
     as = ones(3:4)
     bs = parent(as)
     
-    # LaurentPolynomial accepts OffsetArrays; others do not and throw an ArgumentError
-    @test LaurentPolynomial(as) == LaurentPolynomial(bs, 3)
     
     for P in Ps
-        P == LaurentPolynomial && continue
-        @test P(as) == P(bs)
-        @test P{eltype(as)}(as) == P{eltype(as)}(bs)
-#        P == LaurentPolynomial && continue # XXX move to this
-#        @test_throws ArgumentError P(as) 
-#        @test P{eltype(as)}(as) == P{eltype(as)}(bs)
+        # LaurentPolynomial accepts OffsetArrays; others throw warning
+        if P == LaurentPolynomial
+            @test LaurentPolynomial(as) == LaurentPolynomial(bs, 3)
+        else
+            @test P(as) == P(bs)
+            @test P{eltype(as)}(as) == P{eltype(as)}(bs)
+            # (Or throw an error?)
+            # @test_throws ArgumentError P(as) 
+            # @test P{eltype(as)}(as) == P{eltype(as)}(bs)
+        end
     end
         
     a = [1,1]
@@ -152,9 +154,6 @@ end
         end
         
     end
-
-    @test ImmutablePolynomial{eltype(as)}(as) == ImmutablePolynomial(bs)
-    
 end
 
 

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -251,11 +251,11 @@ end
         @test pX != pS1
         @test pS1 == pS2
         @test pS1 == pS3
-        @test_throws ErrorException pS1 + pX
-        @test_throws ErrorException pS1 - pX
-        @test_throws ErrorException pS1 * pX
-        @test_throws ErrorException pS1 ÷ pX
-        @test_throws ErrorException pS1 % pX
+        @test_throws ArgumentError pS1 + pX
+        @test_throws ArgumentError pS1 - pX
+        @test_throws ArgumentError pS1 * pX
+        @test_throws ArgumentError pS1 ÷ pX
+        @test_throws ArgumentError pS1 % pX
 
         # Testing copying.
         pcpy1 = P([1,2,3,4,5], :y)
@@ -282,7 +282,7 @@ end
         @test p1s ≠ p1x
         @test p1s ≠ p2s
 
-        @test_throws ErrorException p1s ≈ p1x
+        @test_throws ArgumentError p1s ≈ p1x
         @test p1s ≉ p2s
         @test p1s ≈ P([1,2.], :s)
 
@@ -320,7 +320,7 @@ end
         @test zero(P, :x) ≈ zero(P, :y)
         @test one(P, :x) ≈ one(P, :y)
         @test (variable(P, :x) ≈ variable(P, :x))
-        @test_throws ErrorException variable(P, :x) ≈ variable(P, :y)
+        @test_throws ArgumentError variable(P, :x) ≈ variable(P, :y)
 
     end
 end
@@ -600,7 +600,7 @@ end
         @test derivative(pR) == P([-2 // 1,2 // 1])
         @test derivative(p3) == P([2,2])
         @test derivative(p1) == derivative(p0) == derivative(pNULL) == pNULL
-        @test_throws ErrorException derivative(pR, -1)
+        @test_throws ArgumentError derivative(pR, -1)
         @test integrate(P([1,1,0,0]), 0, 2) == 4.0
 
         @test derivative(integrate(pN)) == convert(P{Float64}, pN)

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -627,8 +627,9 @@ end
         @test isequal(pder, P([NaN]))
         @test isequal(pint, P([NaN]))
 
-        pint  = integrate(p, 0.0im)
-        @test isequal(pint, P([NaN]))
+        c = 0.0im
+        pint  = integrate(p, c)
+        @test isequal(pint, P{promote_type(eltype(p), typeof(c)), :x}([NaN]))
 
         # Issue with overflow and polyder Issue #159
         @test derivative(P(BigInt[0, 1])^100, 100) == P(factorial(big(100)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,4 +10,4 @@ using OffsetArrays
 
 @testset "Standard basis" begin include("StandardBasis.jl") end
 @testset "ChebyshevT" begin include("ChebyshevT.jl") end
-#@testset "Poly, Pade (compatability)" begin include("Poly.jl") end
+@testset "Poly, Pade (compatability)" begin include("Poly.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,4 +10,4 @@ using OffsetArrays
 
 @testset "Standard basis" begin include("StandardBasis.jl") end
 @testset "ChebyshevT" begin include("ChebyshevT.jl") end
-@testset "Poly, Pade (compatability)" begin include("Poly.jl") end
+#@testset "Poly, Pade (compatability)" begin include("Poly.jl") end


### PR DESCRIPTION
PR to contain breaking changes, the main one is using the type system to hold the indeterminate rather than use a field to hold the indeterminate. The advantage is this plays better with Julia's promotion mechanisms so matrices of polynomials requires much less fuss. The others are cleanups. For example, iteration is modified to more closely match iteration over the underlying container. Before, iteration iterated over terms, which is still supported though now through the iterator `monomials`.

- [x] As mentioned in #308, a change for how the polynomial symbol is handled moving it from a field to a parameter of the type
- [x] Removal of deprecated usage of `Polynomial` constructor to create different types of polynomials based on how the coefficients are specified. Remove `LaurentPolynomial` deprecations.
- [x] Clean up how `OffsetArrays` are used (ok with Laurent, ignore otherwise) instead of just ignoring offset for all. Removed `OffsetArrays` as a dependency.
- [x] change how collect yields terms (monomial) instead of coefficients. Try to make polynomials act like vectors as much as possible. Introduce a non-exported `monomials` iterator for old behaviour.
- [x] Change type instability in `integrate` with `NaN` values
- [x] make `ErrorException` errors more informative

Non-breaking changes
- [x] Modify docstring to `fit`. (Had planned on changing how weights are specified [issue?], but held back)
- [x] for `integrate` have methods implement `integrate(p)`, not `integrate(p,c)`.
In addition, there are a few speedups to the basic operations for the `ImmutablePolynomial` and `Polynomial` types. 
- [x] Clean up promotion routes for `+` and `*`; refactor for possible reuse. 
- [x] Move code into `common` (truncate!, chop!, zero, one, variable, basis) 
