### PR TITLE
adjust printing tohandle symbolic values

### DIFF
--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -4,11 +4,11 @@ abstract type StandardBasisPolynomial{T} <: AbstractPolynomial{T} end
 
 function showterm(io::IO, ::Type{<:StandardBasisPolynomial}, pj::T, var, j, first::Bool, mimetype) where {T}
 
-    if iszero(pj) return false end
+    if pj === zero(T) return false end
 
     pj = printsign(io, pj, first, mimetype)
 
-    if !(pj == one(T) && !(showone(T) || j == 0))
+    if !(pj === one(T) && !(showone(T) || j == 0))
         printcoefficient(io, pj, j, mimetype)
     end
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -10,10 +10,10 @@ export printpoly
 hasneg(::Type{T}) where {T} = false
 
 "Could value possibly be negative and if so, is it?"
-isneg(pj::T) where {T} = hasneg(T) && pj < zero(T)
+isneg(pj::T) where {T} = hasneg(T) && sign(pj) === -one(T)
 
 "Make `pj` positive if it is negative. (Don't call `abs` as that may not be defined, or appropriate.)"
-aspos(pj::T) where {T} = (hasneg(T) && isneg(pj)) ? -pj : pj
+aspos(pj::T) where {T} = (hasneg(T) && isneg(pj) == true) ? -pj : pj
 
 "Should a value of `one(T)` be shown as a coefficient of monomial `x^i`, `i >= 1`? (`1.0x^2` is shown, `1 x^2` is not)"
 showone(::Type{T}) where {T} = true


### PR DESCRIPTION
Backport adjustments to printing of `Symbolics.Num` numbers 