### PR TITLE
specify type for iterate call

### DIFF
--- a/src/rational-functions/common.jl
+++ b/src/rational-functions/common.jl
@@ -116,7 +116,7 @@ Base.denominator(pq::AbstractRationalFunction) = pq.den
 
 # Treat a RationalFunction as a tuple (num=p, den=q)
 Base.length(pq::AbstractRationalFunction) = 2
-function Base.iterate(pq, state=nothing)
+function Base.iterate(pq::AbstractRationalFunction, state=nothing)
     state == nothing && return (numerator(pq), 1)
     state == 1 && return (denominator(pq), 2)
     nothing


### PR DESCRIPTION
Without this type annotation, this function does type piracy and causes a huge number of invalidations (https://julialang.org/blog/2020/08/invalidations/).