### PR TITLE
Bound GR_jll in docs CI to avoid segfault

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.6.1'
+          version: '1'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,8 +1,10 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
+GR_jll = "d2c73de3-f751-5644-a686-071e5b155ba9"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
-DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
 
 [compat]
 Documenter = "0.24"
+GR_jll = "< 0.58"


### PR DESCRIPTION
For some reason, the docs CI is segfaulting for Julia 1.6.x. First, I thought it was related to version 1.6.2 and tried using 1.6.1 but that one still fails. This PR instead tries ~upgrading Documenter to see if that helps.~ bounding `GR_jll` below version 0.58.

@jverzani I noticed that the docs haven't been deployed for many releases because the TagBot wasn't configured with the `DOCUMENTER_KEY`. I've updated the script so hopefully it will work for future tags. I'm planning to push a docs tag as explained in the "Fixing broken release deployments" section of https://juliadocs.github.io/Documenter.jl/stable/man/hosting/ once docs CI is working again.