### PR TITLE
Upgrade to Documenter 0.27

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,5 +6,5 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.27"
 GR_jll = "< 0.58"


### PR DESCRIPTION
That should allow us to use `+docX` tags if we need to manually fix the docs.