### PR TITLE
typo: \alpha s, not as; breaks SpecialPolynomials.jl with v2.0.16

### DIFF
--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -124,9 +124,9 @@ macro registerN(name, params...)
         end
         $poly{$(αs...)}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {$(αs...),T} =
             $poly{$(αs...),T,Symbol(var)}(coeffs)
-        $poly{$(as...),T,X}(c::AbstractPolynomial{S,Y}) where {$(as...),T,X,S,Y} = convert($poly{$(as...),T,X}, c)
-        $poly{$(as...),T}(c::AbstractPolynomial{S,Y}) where {$(as...),T,S,Y} = convert($poly{$(as...),T}, c)
-        $poly{$(as...),}(c::AbstractPolynomial{S,Y}) where {$(as...),S,Y} = convert($poly{$(as...),}, c)
+        $poly{$(αs...),T,X}(c::AbstractPolynomial{S,Y}) where {$(αs...),T,X,S,Y} = convert($poly{$(αs...),T,X}, c)
+        $poly{$(αs...),T}(c::AbstractPolynomial{S,Y}) where {$(αs...),T,S,Y} = convert($poly{$(αs...),T}, c)
+        $poly{$(αs...),}(c::AbstractPolynomial{S,Y}) where {$(αs...),S,Y} = convert($poly{$(αs...),}, c)
 
         $poly{$(αs...),T,X}(n::Number) where {$(αs...),T,X} = T(n)*one($poly{$(αs...),T,X})
         $poly{$(αs...),T}(n::Number, var::SymbolLike = :x) where {$(αs...),T} = T(n)*one($poly{$(αs...),T,Symbol(var)})


### PR DESCRIPTION
The v2.0.16 is causing problems with SpecialPolynomials.jl, due to typo: the variable is typed as `as` (the letter `a`), but should be `αs` (greek `alpha`: \alpha s), which throws ` UndefVarError: as not defined`. Should be fixed here.

Not sure if it'll be good to add `using SpecialPolynomials` to automated tests to prevent breaking in the future?

Thanks!


> julia> using SpecialPolynomials
> [ Info: Precompiling SpecialPolynomials [a25cea48-d430-424a-8ee7-0d3ad3742e9e]
> ERROR: LoadError: UndefVarError: as not defined
> Stacktrace:
>   [1] var"@registerN"(__source__::LineNumberNode, __module__::Module, name::Any, params::Vararg{Any})
>     @ Polynomials ~/code/jl_repo/Polynomials.jl/src/abstract.jl:113
>   [2] include(mod::Module, _path::String)
>     @ Base ./Base.jl:420
>   [3] include(x::String)
>     @ SpecialPolynomials ~/.julia/packages/SpecialPolynomials/4xW0J/src/SpecialPolynomials.jl:1
>   [4] top-level scope
>     @ ~/.julia/packages/SpecialPolynomials/4xW0J/src/SpecialPolynomials.jl:53
>   [5] include
>     @ ./Base.jl:420 [inlined]
>   [6] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::Nothing)
>     @ Base ./loading.jl:1318
>   [7] top-level scope
>     @ none:1
>   [8] eval
>     @ ./boot.jl:373 [inlined]
>   [9] eval(x::Expr)
>     @ Base.MainInclude ./client.jl:453
>  [10] top-level scope
>     @ none:1
> in expression starting at /Users/david/.julia/packages/SpecialPolynomials/4xW0J/src/Bernstein.jl:40
> in expression starting at /Users/david/.julia/packages/SpecialPolynomials/4xW0J/src/Bernstein.jl:40
> in expression starting at /Users/david/.julia/packages/SpecialPolynomials/4xW0J/src/SpecialPolynomials.jl:1
> ERROR: Failed to precompile SpecialPolynomials [a25cea48-d430-424a-8ee7-0d3ad3742e9e] to /Users/david/.julia/compiled/v1.7/SpecialPolynomials/jl_DZxGsd.
> Stacktrace:
>  [1] error(s::String)
>    @ Base ./error.jl:33
>  [2] compilecache(pkg::Base.PkgId, path::String, internal_stderr::IO, internal_stdout::IO, ignore_loaded_modules::Bool)
>    @ Base ./loading.jl:1466
>  [3] compilecache(pkg::Base.PkgId, path::String)
>    @ Base ./loading.jl:1410
>  [4] _require(pkg::Base.PkgId)
>    @ Base ./loading.jl:1120
>  [5] require(uuidkey::Base.PkgId)
>    @ Base ./loading.jl:1013
>  [6] require(into::Module, mod::Symbol)
>    @ Base ./loading.jl:997