### PR TITLE
add depwarn for `domain`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "2.0.21"
+version = "2.0.22"
 
 [deps]
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"

--- a/src/common.jl
+++ b/src/common.jl
@@ -585,7 +585,10 @@ degree(p::AbstractPolynomial) = iszero(p) ? -1 : lastindex(p)
 Returns the domain of the polynomial.
 """
 domain(::Type{<:AbstractPolynomial})
-domain(::P) where {P <: AbstractPolynomial} = domain(P)
+function domain(::P) where {P <: AbstractPolynomial}
+    Base.depwarn("An exported `domain` will be removed; use `Polynomials.domain`.", :domain)
+    domain(P)
+end
 
 """
     mapdomain(::Type{<:AbstractPolynomial}, x::AbstractArray)


### PR DESCRIPTION
To close Issue #374 it seems the most lightweight way is to simply remove the `Intervals.jl` dependency and replace with internal functions. The only issue is `domain` is re-exported by `Polynomials` by `Intervals`. If we export a `domain` from `Polynomials` going forward, it would conflict with usages of `Intervals`, which seems like a bad idea. Instead, it makes sense to remove `domains` from the exported functions. This PR adds a depwarn to `domain(p::AbstractPolynomial)`.