### PR TITLE
make multiplication of polynomials type stable

### DIFF
--- a/src/contrib.jl
+++ b/src/contrib.jl
@@ -4,14 +4,11 @@ using Base.Cartesian
 
 
 # direct version (do not check if threshold is satisfied)
-@generated function fastconv(E::Array{T,N}, k::Array{T,N}) where {T,N}
-    quote
-        retsize = [size(E)...] + [size(k)...] .- 1
-        retsize = tuple(retsize...)
-        ret = zeros(T, retsize)
-        convn!(ret, E, k)
-        return ret
-    end
+function fastconv(E::Array{T,N}, k::Array{T,N}) where {T,N}
+    retsize = ntuple(n -> size(E, n) + size(k, n) - 1, Val{N}())
+    ret = zeros(T, retsize)
+    convn!(ret, E, k)
+    return ret
 end
 
 # in place helper operation to speedup memory allocations

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -408,6 +408,14 @@ end
         @test pNULL^3 == pNULL
         @test pNULL * pNULL == pNULL
 
+        if P === Polynomial
+            # type stability of multiplication
+            @inferred 10 * pNULL
+            @inferred 10 * p0
+            @inferred p2 * p2
+            @inferred p2 * p2
+        end
+
         @test pNULL + 2 == p0 + 2 == 2 + p0 == P([2])
         @test p2 - 2 == -2 + p2 == P([-1,1])
         @test 2 - p2 == P([1,-1])


### PR DESCRIPTION
I fixed a type instability in `fastconv` used in the multiplication of `Polynomial`s.

Current `master`:
```julia
julia> using Polynomials, BenchmarkTools

julia> p = Polynomial([1, 2, 3])
Polynomial(1 + 2*x + 3*x^2)

julia> @benchmark *($p, $p)
BenchmarkTools.Trial: 10000 samples with 200 evaluations.
 Range (min … max):  412.310 ns …   7.433 μs  ┊ GC (min … max): 0.00% … 93.87%
 Time  (median):     418.565 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   436.345 ns ± 242.029 ns  ┊ GC (mean ± σ):  2.19% ±  3.73%

  ▂▇█▆▂▃▃▁                             ▁▁▁                      ▂
  ████████▇▇▇▇▇▇▆▇▄▅▃▃▁▃▃▄▁▁▃▅▇▇▅▅▇▇███████▇▇▇▇▇▅▅▆▄▄▄▃▄▃▃▅▃▆█▇ █
  412 ns        Histogram: log(frequency) by time        562 ns <

 Memory estimate: 384 bytes, allocs estimate: 7.
```
This PR:
```julia
julia> using Polynomials, BenchmarkTools

julia> p = Polynomial([1, 2, 3])
Polynomial(1 + 2*x + 3*x^2)

julia> @benchmark *($p, $p)
BenchmarkTools.Trial: 10000 samples with 993 evaluations.
 Range (min … max):  34.658 ns … 751.707 ns  ┊ GC (min … max): 0.00% … 94.75%
 Time  (median):     35.883 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   39.452 ns ±  21.572 ns  ┊ GC (mean ± σ):  2.20% ±  4.09%

  ▁█▇▅▂▁              ▁       ▁▁▁                              ▂
  ██████▇▇▇▅▅▆▅▃▃▄▃▃▆██▇██▇▆▇████████▇▆▇▅▆▅▅▇▇▆▆▅▆▅▆▅▅▅▄▅▅▅▄▁▅ █
  34.7 ns       Histogram: log(frequency) by time      78.1 ns <

 Memory estimate: 96 bytes, allocs estimate: 1.
```

It would be great to get a new release with this soon.