### PR TITLE
make the default constructor type stable

### DIFF
--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -83,7 +83,9 @@ macro register(name)
         Base.promote_rule(::Type{<:$poly{T,X}}, ::Type{<:$poly{S,X}}) where {T,S,X} =  $poly{promote_type(T, S),X}
         Base.promote_rule(::Type{<:$poly{T,X}}, ::Type{S}) where {T,S<:Number,X} =
             $poly{promote_type(T, S),X}
-        $poly(coeffs::AbstractVector{T}, var::SymbolLike = :x) where {T} =
+        $poly(coeffs::AbstractVector{T}) where {T} =
+            $poly{T, :x}(coeffs)
+        $poly(coeffs::AbstractVector{T}, var::SymbolLike) where {T} =
             $poly{T, Symbol(var)}(coeffs)
         $poly{T}(x::AbstractVector{S}, var::SymbolLike = :x) where {T,S} =
             $poly{T,Symbol(var)}(T.(x))

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -393,6 +393,10 @@ end
         pN = P([276,3,87,15,24,0])
         pR = P([3 // 4, -2 // 1, 1 // 1])
 
+        # type stability of the default constructor without variable name
+        if P !== ImmutablePolynomial
+            @inferred P([1, 2, 3])
+        end
 
         @test p3 == P([1,2,1])
         @test pN * 10 == P([2760, 30, 870, 150, 240])


### PR DESCRIPTION
Current `master`:
```julia
julia> using Polynomials

julia> @code_warntype Polynomial([1, 2, 3])
MethodInstance for Polynomial(::Vector{Int64})
  from Polynomial(coeffs::AbstractVector{var"#155#T"}) where var"#155#T" in Polynomials at ~/.julia/dev/Polynomials/src/abstract.jl:86
Static Parameters
  #155#T = Int64
Arguments
  #self#::Type{Polynomial}
  coeffs::Vector{Int64}
Body::Polynomial{Int64}
1 ─ %1 = (#self#)(coeffs, :x)::Polynomial{Int64}
└──      return %1
```
Note that `Polynomial{Int64}` is not a concrete type (displayed in red in the REPL).

This PR:
```julia
julia> using Polynomials

julia> @code_warntype Polynomial([1, 2, 3])
MethodInstance for Polynomial(::Vector{Int64})
  from Polynomial(coeffs::AbstractVector{var"#156#T"}) where var"#156#T" in Polynomials at ~/.julia/dev/Polynomials/src/abstract.jl:86
Static Parameters
  #156#T = Int64
Arguments
  #self#::Type{Polynomial}
  coeffs::Vector{Int64}
Body::Polynomial{Int64, :x}
1 ─ %1 = Core.apply_type(Polynomials.Polynomial, $(Expr(:static_parameter, 1)), :x)::Core.Const(Polynomial{Int64, :x})
│   %2 = (%1)(coeffs)::Polynomial{Int64, :x}
└──      return %2
```