### PR TITLE
close issue #395; allow symbol to be passed as Val(:x)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "2.0.24"
+version = "2.0.25"
 
 [deps]
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -2,7 +2,8 @@ export AbstractPolynomial
 
 
 
-const SymbolLike = Union{AbstractString,Char,Symbol}
+const SymbolLike = Union{AbstractString,Char,Symbol, Val{T} where T}
+Base.Symbol(::Val{T}) where {T} = Symbol(T)
 
 """
     AbstractPolynomial{T,X}
@@ -51,7 +52,7 @@ abstract type AbstractPolynomial{T,X} end
 
 # convert `as` into polynomial of type P based on instance, inheriting variable
 # (and for LaurentPolynomial the offset)
-_convert(p::P, as) where {T,X,P <: AbstractPolynomial{T,X}} = ⟒(P)(as, X)
+_convert(p::P, as) where {T,X,P <: AbstractPolynomial{T,X}} = ⟒(P)(as, Val(X))
 
 
 """

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -129,7 +129,7 @@ macro registerN(name, params...)
             $poly{$(αs...),T,Symbol(var)}(T.(x))
         end
         $poly{$(αs...)}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {$(αs...),T} =
-            $poly{$(αs...),T, Symbol(var)}(coeffs)
+            $poly{$(αs...),T,Symbol(var)}(coeffs)
         $poly{$(αs...),T,X}(c::AbstractPolynomial{S,Y}) where {$(αs...),T,X,S,Y} = convert($poly{$(αs...),T,X}, c)
         $poly{$(αs...),T}(c::AbstractPolynomial{S,Y}) where {$(αs...),T,S,Y} = convert($poly{$(αs...),T}, c)
         $poly{$(αs...),}(c::AbstractPolynomial{S,Y}) where {$(αs...),S,Y} = convert($poly{$(αs...),}, c)
@@ -137,9 +137,9 @@ macro registerN(name, params...)
         $poly{$(αs...),T,X}(n::Number) where {$(αs...),T,X} = T(n)*one($poly{$(αs...),T,X})
         $poly{$(αs...),T}(n::Number, var::SymbolLike = :x) where {$(αs...),T} = T(n)*one($poly{$(αs...),T,Symbol(var)})
         $poly{$(αs...)}(n::S, var::SymbolLike = :x) where {$(αs...), S<:Number} =
-            n*one($poly{$(αs...),S, Symbol(var)})
+            n*one($poly{$(αs...),S,Symbol(var)})
         $poly{$(αs...),T}(var::SymbolLike=:x) where {$(αs...), T} = variable($poly{$(αs...),T,Symbol(var)})
-        $poly{$(αs...)}(var::SymbolLike=:x) where {$(αs...)} = variable($poly{$(αs...)},Symboly(var))
+        $poly{$(αs...)}(var::SymbolLike=:x) where {$(αs...)} = variable($poly{$(αs...)},Symbol(var))
         (p::$poly)(x) = evalpoly(x, p)
     end
 end

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -3,7 +3,8 @@ export AbstractPolynomial
 
 
 const SymbolLike = Union{AbstractString,Char,Symbol, Val{T} where T}
-Base.Symbol(::Val{T}) where {T} = Symbol(T)
+varsymbol(x) = Symbol(x)
+varsymbol(::Val{T}) where {T} = Symbol(T)
 
 """
     AbstractPolynomial{T,X}
@@ -87,13 +88,13 @@ macro register(name)
         $poly(coeffs::AbstractVector{T}) where {T} =
             $poly{T, :x}(coeffs)
         $poly(coeffs::AbstractVector{T}, var::SymbolLike) where {T} =
-            $poly{T, Symbol(var)}(coeffs)
+            $poly{T, varsymbol(var)}(coeffs)
         $poly{T}(x::AbstractVector{S}, var::SymbolLike = :x) where {T,S} =
-            $poly{T,Symbol(var)}(T.(x))
+            $poly{T,varsymbol(var)}(T.(x))
         function $poly(coeffs::G, var::SymbolLike=:x) where {G}
             !Base.isiterable(G) && throw(ArgumentError("coeffs is not iterable"))
             cs = collect(coeffs)
-            $poly{eltype(cs), Symbol(var)}(cs)
+            $poly{eltype(cs), varsymbol(var)}(cs)
         end
         $poly{T,X}(c::AbstractPolynomial{S,Y}) where {T,X,S,Y} = convert($poly{T,X}, c)
         $poly{T}(c::AbstractPolynomial{S,Y}) where {T,S,Y} = convert($poly{T}, c)
@@ -101,10 +102,10 @@ macro register(name)
         $poly{T,X}(n::S) where {T, X, S<:Number} =
             T(n) *  one($poly{T, X})
         $poly{T}(n::S, var::SymbolLike = :x) where {T, S<:Number} =
-            T(n) *  one($poly{T, Symbol(var)})
-        $poly(n::S, var::SymbolLike = :x)  where {S  <: Number} = n * one($poly{S, Symbol(var)})
-        $poly{T}(var::SymbolLike=:x) where {T} = variable($poly{T, Symbol(var)})
-        $poly(var::SymbolLike=:x) = variable($poly, Symbol(var))
+            T(n) *  one($poly{T, varsymbol(var)})
+        $poly(n::S, var::SymbolLike = :x)  where {S  <: Number} = n * one($poly{S, varsymbol(var)})
+        $poly{T}(var::SymbolLike=:x) where {T} = variable($poly{T, varsymbol(var)})
+        $poly(var::SymbolLike=:x) = variable($poly, varsymbol(var))
         (p::$poly)(x) = evalpoly(x, p)
     end
 end
@@ -123,20 +124,20 @@ macro registerN(name, params...)
             $poly{$(αs...),promote_type(T,S),X}
 
         function $poly{$(αs...),T}(x::AbstractVector{S}, var::SymbolLike = :x) where {$(αs...),T,S}
-            $poly{$(αs...),T, Symbol(var)}(T.(x))
+            $poly{$(αs...),T, varsymbol(var)}(T.(x))
         end
         $poly{$(αs...)}(coeffs::AbstractVector{T}, var::SymbolLike=:x) where {$(αs...),T} =
-            $poly{$(αs...),T,Symbol(var)}(coeffs)
+            $poly{$(αs...),T, varsymbol(var)}(coeffs)
         $poly{$(αs...),T,X}(c::AbstractPolynomial{S,Y}) where {$(αs...),T,X,S,Y} = convert($poly{$(αs...),T,X}, c)
         $poly{$(αs...),T}(c::AbstractPolynomial{S,Y}) where {$(αs...),T,S,Y} = convert($poly{$(αs...),T}, c)
         $poly{$(αs...),}(c::AbstractPolynomial{S,Y}) where {$(αs...),S,Y} = convert($poly{$(αs...),}, c)
 
         $poly{$(αs...),T,X}(n::Number) where {$(αs...),T,X} = T(n)*one($poly{$(αs...),T,X})
-        $poly{$(αs...),T}(n::Number, var::SymbolLike = :x) where {$(αs...),T} = T(n)*one($poly{$(αs...),T,Symbol(var)})
+        $poly{$(αs...),T}(n::Number, var::SymbolLike = :x) where {$(αs...),T} = T(n)*one($poly{$(αs...),T,varsymbol(var)})
         $poly{$(αs...)}(n::S, var::SymbolLike = :x) where {$(αs...), S<:Number} =
-            n*one($poly{$(αs...),S,Symbol(var)})
-        $poly{$(αs...),T}(var::SymbolLike=:x) where {$(αs...), T} = variable($poly{$(αs...),T,Symbol(var)})
-        $poly{$(αs...)}(var::SymbolLike=:x) where {$(αs...)} = variable($poly{$(αs...)},Symbol(var))
+            n*one($poly{$(αs...),S, varsymbol(var)})
+        $poly{$(αs...),T}(var::SymbolLike=:x) where {$(αs...), T} = variable($poly{$(αs...),T,varsymbol(var)})
+        $poly{$(αs...)}(var::SymbolLike=:x) where {$(αs...)} = variable($poly{$(αs...)},varsymbol(var))
         (p::$poly)(x) = evalpoly(x, p)
     end
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -775,7 +775,7 @@ function Base.zero(::Type{P}) where {P<:AbstractPolynomial}
     T,X = eltype(P), indeterminate(P)
     ⟒(P){T,X}(zeros(T,1))
 end
-Base.zero(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = zero(⟒(P){eltype(P),Symbol(var)}) #default 0⋅b₀
+Base.zero(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = zero(⟒(P){eltype(P), varsymbol(var)}) #default 0⋅b₀
 Base.zero(p::P, var=indeterminate(p)) where {P <: AbstractPolynomial} = zero(P, var)
 """
     one(::Type{<:AbstractPolynomial})
@@ -816,7 +816,7 @@ julia> roots((x - 3) * (x + 2))
 ```
 """
 variable(::Type{P}) where {P <: AbstractPolynomial} = throw(ArgumentError("No default method defined")) # no default
-variable(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = variable(⟒(P){eltype(P),Symbol(var)})
+variable(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = variable(⟒(P){eltype(P), varsymbol(var)})
 variable(p::AbstractPolynomial, var = indeterminate(p)) = variable(typeof(p), var)
 variable(var::SymbolLike = :x) = variable(Polynomial{Int}, var)
 
@@ -830,7 +830,7 @@ function basis(::Type{P}, k::Int) where {P<:AbstractPolynomial}
     ⟒(P){eltype(P), indeterminate(P)}(zs)
 end
 function basis(::Type{P}, k::Int, _var::SymbolLike; var=_var) where {P <: AbstractPolynomial}
-    T,X = eltype(P), Symbol(var)
+    T,X = eltype(P), varsymbol(var)
     basis(⟒(P){T,X}, k)
 end
 basis(p::P, k::Int, _var=indeterminate(p); var=_var) where {P<:AbstractPolynomial} = basis(P, k, var)

--- a/src/common.jl
+++ b/src/common.jl
@@ -775,7 +775,7 @@ function Base.zero(::Type{P}) where {P<:AbstractPolynomial}
     T,X = eltype(P), indeterminate(P)
     ⟒(P){T,X}(zeros(T,1))
 end
-Base.zero(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = zero(⟒(P){eltype(P), varsymbol(var)}) #default 0⋅b₀
+Base.zero(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = zero(⟒(P){eltype(P), Symbol(var)}) #default 0⋅b₀
 Base.zero(p::P, var=indeterminate(p)) where {P <: AbstractPolynomial} = zero(P, var)
 """
     one(::Type{<:AbstractPolynomial})
@@ -816,7 +816,7 @@ julia> roots((x - 3) * (x + 2))
 ```
 """
 variable(::Type{P}) where {P <: AbstractPolynomial} = throw(ArgumentError("No default method defined")) # no default
-variable(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = variable(⟒(P){eltype(P), varsymbol(var)})
+variable(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = variable(⟒(P){eltype(P), Symbol(var)})
 variable(p::AbstractPolynomial, var = indeterminate(p)) = variable(typeof(p), var)
 variable(var::SymbolLike = :x) = variable(Polynomial{Int}, var)
 
@@ -830,7 +830,7 @@ function basis(::Type{P}, k::Int) where {P<:AbstractPolynomial}
     ⟒(P){eltype(P), indeterminate(P)}(zs)
 end
 function basis(::Type{P}, k::Int, _var::SymbolLike; var=_var) where {P <: AbstractPolynomial}
-    T,X = eltype(P), varsymbol(var)
+    T,X = eltype(P), Symbol(var)
     basis(⟒(P){T,X}, k)
 end
 basis(p::P, k::Int, _var=indeterminate(p); var=_var) where {P<:AbstractPolynomial} = basis(P, k, var)

--- a/src/common.jl
+++ b/src/common.jl
@@ -775,7 +775,7 @@ function Base.zero(::Type{P}) where {P<:AbstractPolynomial}
     T,X = eltype(P), indeterminate(P)
     ⟒(P){T,X}(zeros(T,1))
 end
-Base.zero(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = zero(⟒(P){eltype(P), Symbol(var)}) #default 0⋅b₀
+Base.zero(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = zero(⟒(P){eltype(P),Symbol(var)}) #default 0⋅b₀
 Base.zero(p::P, var=indeterminate(p)) where {P <: AbstractPolynomial} = zero(P, var)
 """
     one(::Type{<:AbstractPolynomial})
@@ -816,7 +816,7 @@ julia> roots((x - 3) * (x + 2))
 ```
 """
 variable(::Type{P}) where {P <: AbstractPolynomial} = throw(ArgumentError("No default method defined")) # no default
-variable(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = variable(⟒(P){eltype(P), Symbol(var)})
+variable(::Type{P}, var::SymbolLike) where {P <: AbstractPolynomial} = variable(⟒(P){eltype(P),Symbol(var)})
 variable(p::AbstractPolynomial, var = indeterminate(p)) = variable(typeof(p), var)
 variable(var::SymbolLike = :x) = variable(Polynomial{Int}, var)
 

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -24,7 +24,7 @@ struct Poly{T <: Number,X} <: Polynomials.StandardBasisPolynomial{T,X}
     coeffs::Vector{T}
     function Poly(a::AbstractVector{T}, var::Polynomials.SymbolLike = :x) where {T <: Number}
         # if a == [] we replace it with a = [0]
-        X = Polynomials.varsymbol(var)
+        X = Symbol(var)
         if length(a) == 0
             return new{T,X}(zeros(T, 1))
         else

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -3,6 +3,7 @@ module PolyCompat
 using ..Polynomials
 indeterminate = Polynomials.indeterminate
 
+
 #=
 Compat support for old code. This will be opt-in by v1.0, through "using Polynomials.PolyCompat"
 =#
@@ -23,7 +24,7 @@ struct Poly{T <: Number,X} <: Polynomials.StandardBasisPolynomial{T,X}
     coeffs::Vector{T}
     function Poly(a::AbstractVector{T}, var::Polynomials.SymbolLike = :x) where {T <: Number}
         # if a == [] we replace it with a = [0]
-        X = Symbol(var)
+        X = Polynomials.varsymbol(var)
         if length(a) == 0
             return new{T,X}(zeros(T, 1))
         else

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -393,9 +393,10 @@ end
         pN = P([276,3,87,15,24,0])
         pR = P([3 // 4, -2 // 1, 1 // 1])
 
-        # type stability of the default constructor without variable name
+        # type stability of the default constructor with/without variable name
         if P !== ImmutablePolynomial
             @inferred P([1, 2, 3])
+            @inferred P([1,2,3], Val(:x))
         end
 
         @test p3 == P([1,2,1])
@@ -450,6 +451,11 @@ end
     x = variable(LaurentPolynomial)
     @test Polynomials.isconstant(x * inv(x))
     @test_throws ArgumentError inv(x + x^2)
+
+    # issue #395
+    p = Polynomial([2,1], :s)
+    @inferred -p # issue #395
+
 end
 
 @testset "Divrem" begin

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -57,6 +57,10 @@ isimmutable(::Type{<:ImmutablePolynomial}) = true
         @test_throws InexactError P{Int}([1+im, 1], :x)
         @test_throws InexactError P{Int,:x}(1+im)
         @test_throws InexactError P{Int}(1+im)
+
+        ## issue #395
+        v = [1,2,3]
+        @test P(v) == P(v,:x) == P(v,'x') == P(v,"x") == P(v, Val(:x))
     end
 
 end

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -60,7 +60,7 @@ isimmutable(::Type{<:ImmutablePolynomial}) = true
 
         ## issue #395
         v = [1,2,3]
-        @test P(v) == P(v,:x) == P(v,'x') == P(v,"x") == P(v, Val(:x))
+        @test P(v) == P(v,:x) == P(v,'x') == P(v,"x") == P(v, Polynomials.Var(:x))
     end
 
 end
@@ -400,7 +400,7 @@ end
         # type stability of the default constructor with/without variable name
         if P !== ImmutablePolynomial
             @inferred P([1, 2, 3])
-            @inferred P([1,2,3], Val(:x))
+            @inferred P([1,2,3], Polynomials.Var(:x))
         end
 
         @test p3 == P([1,2,1])


### PR DESCRIPTION
* allows type inference when passing indeterminate through constructor as an argument.