### PR TITLE
fix bug printing complex leading terms with negative real part

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "3.1.4"
+version = "3.1.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -284,7 +284,7 @@ julia> z = variable(LaurentPolynomial, :z)
 LaurentPolynomial(1.0*z)
 
 julia> p = LaurentPolynomial([im, 1+im, 2 + im], -1, :z)
-LaurentPolynomial(im*z⁻¹ + 1 + im + (2 + im)z)
+LaurentPolynomial(im*z⁻¹ + (1 + im) + (2 + im)z)
 
 julia> conj(p)(conj(z)) ≈ conj(p(z))
 true

--- a/src/show.jl
+++ b/src/show.jl
@@ -255,7 +255,7 @@ function printcoefficient(io::IO, pj::S, j, mimetype) where {T,S <: Complex{T}}
     hasimag = !iszero(b) || isnan(b) || isinf(b)
 
     if hasreal && hasimag
-        iszero(j) || print(io, "(")
+        print(io, "(")
         print(io, a)
 
         # print b
@@ -277,7 +277,7 @@ function printcoefficient(io::IO, pj::S, j, mimetype) where {T,S <: Complex{T}}
         end
 
         print(io, imagsymbol(mimetype))
-        iszero(j) || print(io, ")")
+        print(io, ")")
 
     elseif hasreal
 

--- a/test/Poly.jl
+++ b/test/Poly.jl
@@ -295,7 +295,7 @@ p = Poly([1.0, 2.0, 3.0, 1.0])
 p = Poly([1, im])
 @test repr(p) == "$Poly(1 + im*x)"
 p = Poly([1+im, 1-im, -1+im, -1 - im])# minus signs
-@test repr(p) == "$Poly(1 + im + (1 - im)x - (1 - im)x^2 - (1 + im)x^3)"
+@test repr(p) == "$Poly((1 + im) + (1 - im)x - (1 - im)x^2 - (1 + im)x^3)"
 p = Poly([1.0, 0 + NaN*im, NaN, Inf, 0 - Inf*im]) # handle NaN or Inf appropriately
 @test repr(p) == "$Poly(1.0 + NaN*im*x + NaN*x^2 + Inf*x^3 - Inf*im*x^4)"
 
@@ -304,7 +304,7 @@ p = Poly([1,2,3])
 p = Poly([1//2, 2//3, 1])
 @test repr("text/latex", p) == "\$\\frac{1}{2} + \\frac{2}{3}\\cdot x + x^{2}\$"
 p = Poly([complex(1,1),complex(0,1),complex(1,0),complex(1,1)])
-@test repr("text/latex", p) == "\$1 + i + i\\cdot x + x^{2} + (1 + i)x^{3}\$"
+@test repr("text/latex", p) == "\$(1 + i) + i\\cdot x + x^{2} + (1 + i)x^{3}\$"
 
 # customized printing with printpoly
 function printpoly_to_string(args...; kwargs...)

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -1392,7 +1392,7 @@ end
         @test sprint(show, p) == "$P(1.0 + 2.0*x + 3.0*x^2)"
 
         p = P([1 + 1im, -2im])
-        @test sprint(show, p) == "$P(1 + im - 2im*x)"
+        @test sprint(show, p) == "$P((1 + im) - 2im*x)"
 
 
         p = P([1,2,3,1])  # leading coefficient of 1
@@ -1402,7 +1402,7 @@ end
         p = P([1, im])
         @test repr(p) == "$P(1 + im*x)"
         p = P([1 + im, 1 - im, -1 + im, -1 - im])# minus signs
-        @test repr(p) == "$P(1 + im + (1 - im)x - (1 - im)x^2 - (1 + im)x^3)"
+        @test repr(p) == "$P((1 + im) + (1 - im)x - (1 - im)x^2 - (1 + im)x^3)"
         p = P([1.0, 0 + NaN * im, NaN, Inf, 0 - Inf * im]) # handle NaN or Inf appropriately
         @test repr(p) == "$P(1.0 + NaN*im*x + NaN*x^2 + Inf*x^3 - Inf*im*x^4)"
 
@@ -1412,13 +1412,13 @@ end
         p = P([1 // 2, 2 // 3, 1])
         @test repr("text/latex", p) == "\$\\frac{1}{2} + \\frac{2}{3}\\cdot x + x^{2}\$"
         p = P([complex(1,1),complex(0,1),complex(1,0),complex(1,1)])
-        @test repr("text/latex", p) == "\$1 + i + i\\cdot x + x^{2} + (1 + i)x^{3}\$"
+        @test repr("text/latex", p) == "\$(1 + i) + i\\cdot x + x^{2} + (1 + i)x^{3}\$"
 
         @test printpoly_to_string(P([1,2,3], "y")) == "1 + 2*y + 3*y^2"
         @test printpoly_to_string(P([1,2,3], "y"), descending_powers = true) == "3*y^2 + 2*y + 1"
         @test printpoly_to_string(P([2, 3, 1], :z), descending_powers = true, offset = -2) == "1 + 3*z^-1 + 2*z^-2"
         @test printpoly_to_string(P([-1, 0, 1], :z), offset = -1, descending_powers = true) == "z - z^-1"
-        @test printpoly_to_string(P([complex(1,1),complex(1,-1)]),MIME"text/latex"()) == "1 + i + (1 - i)x"
+        @test printpoly_to_string(P([complex(1,1),complex(1,-1)]),MIME"text/latex"()) == "(1 + i) + (1 - i)x"
     end
 
     ## closed issues
@@ -1428,7 +1428,7 @@ end
     io=IOBuffer(); printpoly(io, p, compact=true, mulsymbol=""); @test String(take!(io)) == "1.23457 + 2.34568x"
 
     ## issue 278 with complex
-    @test printpoly_to_string(Polynomial([1 + im, 1, 2, im, 2im, 1+im, 1-im])) == "1 + im + x + 2*x^2 + im*x^3 + 2im*x^4 + (1 + im)x^5 + (1 - im)x^6"
+    @test printpoly_to_string(Polynomial([1 + im, 1, 2, im, 2im, 1+im, 1-im])) == "(1 + im) + x + 2*x^2 + im*x^3 + 2im*x^4 + (1 + im)x^5 + (1 - im)x^6"
 
     ## issue #320 (fix was broken)
     @test printpoly_to_string(Polynomial(BigInt[1,0,1], :y)) == "1 + y^2"


### PR DESCRIPTION
The issue was how a leading term of a polynomial with complex coefficients printed when the term had both real and imaginary parts and the real part was negative. In this case, there needs to be parentheses, as basically `-(a - bim)` is printed. Unfortunately, this fix is a bit simple, so when a is positive instead of just printing `a + bim` it prints `(a + bim)`. (Adjusting that would require some internal modification that might break others code, should they be overriding the show mechanisms.) As such, tests for printing needed adjustment. Despite changes to the tests, this is viewed as non-breaking -- just a bug fix -- in terms of semantic versioning.