### PR TITLE
Replace inefficient broadcast with `copyto!`

### DIFF
--- a/src/polynomials/ngcd.jl
+++ b/src/polynomials/ngcd.jl
@@ -266,7 +266,7 @@ function ngcd(p::PnPolynomial{T,X},
 
     nr, nc = size(Sₓ) # m+1, m-n+2
     F = qr(Sₓ)
-    Q[1:nr, 1:nr] .= F.Q
+    copyto!(view(Q, 1:nr, 1:nr), F.Q)
     R[1:nc, 1:nc] .= F.R
 
     # tolerances

--- a/src/polynomials/ngcd.jl
+++ b/src/polynomials/ngcd.jl
@@ -266,7 +266,9 @@ function ngcd(p::PnPolynomial{T,X},
 
     nr, nc = size(Sₓ) # m+1, m-n+2
     F = qr(Sₓ)
-    copyto!(view(Q, 1:nr, 1:nr), F.Q)
+    dest = view(Q, 1:nr, 1:nr)
+    copyto!(dest, I)
+    lmul!(F.Q, dest)
     R[1:nc, 1:nc] .= F.R
 
     # tolerances


### PR DESCRIPTION
This came up in a nanosoldier run in https://github.com/JuliaLang/julia/pull/46196. Independently from that PR, the broadcasting used here previously is super slow in any case, because it computes elementwise `getindex` which needs to be computed and is not readily readable. The proposed change should speed this step up significantly, at least on Julia v1.7+, see https://github.com/JuliaLang/julia/pull/39533.