### PR TITLE
remove promote_rule method; add type information to any definition

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "3.1.6"
+version = "3.1.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/common.jl
+++ b/src/common.jl
@@ -431,9 +431,6 @@ function Base.convert(::Type{T}, p::AbstractPolynomial{T,X}) where {T <: Number,
 end
 
 # Methods to ensure that matrices of polynomials behave as desired
-Base.promote_rule(::Type{<:AbstractPolynomial{T}},
-                  ::Type{<:AbstractPolynomial{S}},
-                  ) where {T,S} = Polynomial{promote_type(T, S)}
 Base.promote_rule(::Type{P},::Type{Q}) where {T,X, P<:AbstractPolynomial{T,X},
                                               S,   Q<:AbstractPolynomial{S,X}} =
                                                    Polynomial{promote_type(T, S),X}
@@ -485,7 +482,7 @@ Base.all(pred, p::AbstractPolynomial) = all(pred, values(p))
 
 Test whether any coefficient of an `AbstractPolynomial` satisfies predicate `pred`.
 """
-Base.any(pred, p::AbstractPolynomial) = any(pred, values(p))
+Base.any(pred, p::AbstractPolynomial{T,X}) where {T, X} = any(pred, values(p))
 
 
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -476,7 +476,7 @@ Test whether all coefficients of an `AbstractPolynomial` satisfy predicate `pred
 
 You can implement `isreal`, etc., to a `Polynomial` by using `all`.
 """
-Base.all(pred, p::AbstractPolynomial) = all(pred, values(p))
+Base.all(pred, p::AbstractPolynomial{T, X}) where {T,X} = all(pred, values(p))
 """
     any(pred, poly::AbstractPolynomial)
 

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -83,7 +83,10 @@ function Base.convert(C::Type{<:ChebyshevT}, p::Polynomial)
     p(x)
 end
 
-Base.promote_rule(::Type{P},::Type{Q}) where {T, X, P <: LaurentPolynomial{T,X}, S, Q <: ChebyshevT{S, X}} = LaurentPolynomial{promote_type(T, S), X}
+Base.promote_rule(::Type{P},::Type{Q}) where {
+    T, X, P <: LaurentPolynomial{T,X},
+    S, Q <: ChebyshevT{S, X}} =
+        LaurentPolynomial{promote_type(T, S), X}
 
 domain(::Type{<:ChebyshevT}) = Interval(-1, 1)
 function Base.one(::Type{P}) where {P<:ChebyshevT}


### PR DESCRIPTION
In #403 @jishnub points out an issue with a `promote_rule` definition, which turns out is unnecessary. This was removed. As well, the specialization of `Base.any` for abstract polynomials was causing an invalidation on testing, this was addressed.