### PR TITLE
Add `Base.:+(p::AbstractPolynomial)`

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -839,6 +839,8 @@ Base.:-(p1::AbstractPolynomial, p2::AbstractPolynomial) = +(p1, -p2)
 ## +(p::P,c::Number) and +(p::P, q::Q) where {T,S,X,P<:SubtypePolynomial{T,X},Q<:SubtypePolynomial{S,X}}
 ## though the default for poly+poly isn't terrible
 
+Base.:+(p::AbstractPolynomial) = p
+
 # polynomial + scalar; implicit identification of c with c*one(P)
 Base.:+(p::P, c::T) where {T,X, P<:AbstractPolynomial{T,X}} = p + c * one(P)
 

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -161,6 +161,7 @@ end
             @test_throws ArgumentError p*d == P([cᵢ*d for cᵢ ∈ [a,b,c]]) # can't fix
 
             # poly add
+            @test +p == p
             @test p + q == P([a+a,b+b,c])
             @test p - q == P([a-a,b-b,c])
             @test p - p == P([0*a])
@@ -211,6 +212,7 @@ end
             @test p*d == P([cᵢ*d for cᵢ ∈ [a,b,c]])
 
             # poly add
+            @test +p == p
             @test p + q == P([a+a,b+b,c])
             @test p - q == P([a-a,b-b,c])
             @test_throws MethodError p - p == P([0*a])  # no zeros to make zero polynomial
@@ -260,6 +262,7 @@ end
             @test_throws MethodError p*d == P([cᵢ*d for cᵢ ∈ [a,b,c]]) # Ok, no * for T
 
             # poly add
+            @test +p == p
             @test p + q == P([a+a,b+b,c])
             @test p - q == P([a-a,b-b,c])
             @test_throws MethodError p - p == P([0*a])  # no zero(T) to make zero polynomial
@@ -313,6 +316,7 @@ end
                 @test p*d == P([cᵢ*d for cᵢ ∈ [a,b,c]])
 
                 # poly add
+                @test +p == p
                 @test p + q == P([a+a,b+b,c])
                 @test p - p == P([0*a])
 


### PR DESCRIPTION
This PR adds `Base.:+(p::AbstractPolynomial)` just like `+(x::Number) = x` in `Base`.

**Before this PR**
```julia
julia> using Polynomials

julia> q = Polynomial([1,2,3])
Polynomial(1 + 2*x + 3*x^2)

julia> +q
ERROR: MethodError: no method matching +(::Polynomial{Int64, :x})
Closest candidates are:
  +(::P1, ::P2) where {T, X, P1<:Polynomial{T, X}, S, P2<:Polynomial{S, X}} at ~/.julia/dev/Polynomials/src/polynomials/Polynomial.jl:75
  +(::P, ::S) where {T, X, P<:Polynomial{T, X}, S<:Number} at ~/.julia/dev/Polynomials/src/polynomials/Polynomial.jl:58
  +(::P, ::P) where {T, X, P<:AbstractPolynomial{T, X}} at ~/.julia/dev/Polynomials/src/common.jl:864
  ...
Stacktrace:
 [1] top-level scope
   @ REPL[6]:1

julia> a = 3
3

julia> +a
3
```

**After this PR**
```julia
julia> using Polynomials

julia> q = Polynomial([1,2,3])
Polynomial(1 + 2*x + 3*x^2)

julia> +q
Polynomial(1 + 2*x + 3*x^2)

julia> a = 3
3

julia> +a
3
```

