### PR TITLE
Reduce unbound args

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -944,12 +944,7 @@ function scalar_mult(c::S, p::P) where {S, T, X, P<:AbstractPolynomial{T, X}}
     𝐏([c * pᵢ for pᵢ ∈ coeffs(p)])
 end
 
-scalar_mult(c::S, p::Union{P, R}) where {
-    S<: AbstractPolynomial,
-    T, X,
-    P<:AbstractPolynomial{T, X},
-    R <:AbstractPolynomial{T}
-} = throw(DomainError()) # avoid ambiguity, issue #435
+scalar_mult(p1::AbstractPolynomial, p2::AbstractPolynomial) = error("scalar_mult(::$(typeof(p1)), ::$(typeof(p2))) is not defined.") # avoid ambiguity, issue #435
 
 function Base.:/(p::P, c::S) where {P <: AbstractPolynomial,S}
     _convert(p, coeffs(p) ./ c)

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -271,7 +271,7 @@ function Base.divrem(num::ChebyshevT{T,X}, den::ChebyshevT{S,Y}) where {T,X,S,Y}
     return P(q_coeff), P(r_coeff)
 end
 
-function showterm(io::IO, ::Type{ChebyshevT{T,X}}, pj::T, var, j, first::Bool, mimetype) where {N, T,X}
+function showterm(io::IO, ::Type{ChebyshevT{T,X}}, pj::T, var, j, first::Bool, mimetype) where {T,X}
     iszero(pj) && return false
     !first &&  print(io, " ")
     if hasneg(T)

--- a/src/rational-functions/common.jl
+++ b/src/rational-functions/common.jl
@@ -82,7 +82,7 @@ function Base.convert(::Type{P}, pq::PQ) where {P<:AbstractPolynomial, PQ<:Abstr
     convert(P, p) / constantterm(q)
 end
 
-function Base.convert(::Type{S}, pq::PQ) where {S<:Number, T,X,P,PQ<:AbstractRationalFunction}
+function Base.convert(::Type{S}, pq::PQ) where {S<:Number, PQ<:AbstractRationalFunction}
     !isconstant(pq) && throw(ArgumentError("Can't convert non-constant rational function to a number"))
     S(pq(0))
 end


### PR DESCRIPTION
This PR reduces the number of methods with unbround args from 13 to 10. I was trying to reduce it to zero by replacing `NTuple{N,T}` with `Tuple{T, Vararg{T, N}}` but that breaks tests, so I have not applied the changes.

**Before this PR**
```julia
julia> using Polynomials, Test

julia> detect_unbound_args(Polynomials)
Skipping Polynomials.order
[1] truncate(ps::Tuple{Vararg{T, N}}; rtol, atol) where {N, T} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:288
[2] _norm(a::Tuple{Vararg{T, N}}, p::Real) where {T, N} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/polynomials/ImmutablePolynomial.jl:251
[3] ⊗(::Type{<:Polynomials.StandardBasisPolynomial}, p1::Tuple{Vararg{T, N}}, p2::Tuple{Vararg{S, M}}) where {T, N, S, M} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/polynomials/standard-basis.jl:113
[4] var"#truncate#29"(rtol::Real, atol::Real, ::typeof(truncate), ps::Tuple{Vararg{T, N}}) where {N, T} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:288
[5] var"#chop#40"(rtol::Real, atol::Real, ::typeof(chop), ps::Tuple{Vararg{T, N}}) where {N, T} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:356
[6] (::Base.var"#chop##kw")(::Any, ::typeof(chop), ps::Tuple{Vararg{T, N}}) where {N, T} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:356
[7] (::Base.var"#truncate##kw")(::Any, ::typeof(truncate), ps::Tuple{Vararg{T, N}}) where {N, T} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:288
[8] ⊕(P::Type{<:AbstractPolynomial}, p1::Tuple{Vararg{T, N}}, p2::Tuple{Vararg{S, M}}) where {T, N, S, M} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:888
[9] showterm(io::IO, ::Type{ChebyshevT{T, X}}, pj::T, var, j, first::Bool, mimetype) where {N, T, X} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/polynomials/ChebyshevT.jl:274
[10] scalar_mult(c::S, p::Union{P, R}) where {S<:AbstractPolynomial, T, X, P<:AbstractPolynomial{T, X}, R<:(AbstractPolynomial{T})} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:952
[11] _norm(a::Tuple{Vararg{T, N}}) where {T, N} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/polynomials/ImmutablePolynomial.jl:235
[12] chop(ps::Tuple{Vararg{T, N}}; rtol, atol) where {N, T} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:356
[13] convert(::Type{S}, pq::PQ) where {S<:Number, T, X, P, PQ<:Polynomials.AbstractRationalFunction} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/rational-functions/common.jl:85

julia> detect_ambiguities(Polynomials)
Skipping Polynomials.order
Tuple{Method, Method}[]
```

**After this PR**
```julia
julia> using Polynomials, Test

julia> detect_unbound_args(Polynomials)
Skipping Polynomials.order
[1] chop(ps::Tuple{Vararg{T, N}}; rtol, atol) where {N, T} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:356
[2] var"#chop#40"(rtol::Real, atol::Real, ::typeof(chop), ps::Tuple{Vararg{T, N}}) where {N, T} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:356
[3] ⊗(::Type{<:Polynomials.StandardBasisPolynomial}, p1::Tuple{Vararg{T, N}}, p2::Tuple{Vararg{S, M}}) where {T, N, S, M} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/polynomials/standard-basis.jl:113
[4] var"#truncate#29"(rtol::Real, atol::Real, ::typeof(truncate), ps::Tuple{Vararg{T, N}}) where {N, T} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:288
[5] _norm(a::Tuple{Vararg{T, N}}, p::Real) where {T, N} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/polynomials/ImmutablePolynomial.jl:251
[6] truncate(ps::Tuple{Vararg{T, N}}; rtol, atol) where {N, T} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:288
[7] _norm(a::Tuple{Vararg{T, N}}) where {T, N} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/polynomials/ImmutablePolynomial.jl:235
[8] (::Base.var"#truncate##kw")(::Any, ::typeof(truncate), ps::Tuple{Vararg{T, N}}) where {N, T} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:288
[9] (::Base.var"#chop##kw")(::Any, ::typeof(chop), ps::Tuple{Vararg{T, N}}) where {N, T} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:356
[10] ⊕(P::Type{<:AbstractPolynomial}, p1::Tuple{Vararg{T, N}}, p2::Tuple{Vararg{S, M}}) where {T, N, S, M} in Polynomials at /home/hyrodium/.julia/dev/Polynomials/src/common.jl:888

julia> detect_ambiguities(Polynomials)
Skipping Polynomials.order
Tuple{Method, Method}[]
```


