### PR TITLE
adjust some doc strings

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -231,6 +231,9 @@ extrema(p, cps)  # (-2.0, Inf)
 cps = Polynomials.critical_points(p, (0, 2))
 extrema(p, cps)  # (-2.0, 2.0)
 ```
+
+!!! note
+    There is a *big* difference between `minimum(p)` and `minimum(p, cps)`. The former takes the viewpoint that a polynomial `p` is a certain type of vector of its coefficients; returning the smallest coefficient. The latter uses `p` as a callable object, returning the smallest of the values `p.(cps)`.
 """
 function critical_points(p::AbstractPolynomial{T}, I = domain(p);
                          endpoints::Bool=true) where {T <: Real}


### PR DESCRIPTION
Adjust some docstrings to

* close #467 . Unfortunately, I couldn't see how to integrate or differentiate the `ArnoldiFit` form for a polynomial
* close #459 . Rather than make special methods for `minimum` etc. this adds a note in the documentation for `critical_points` about the difference between, say. `minimum(p)` and `minimum(p, itr)`.