### PR TITLE
less typed return of fit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "3.2.6"
+version = "3.2.7"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/common.jl
+++ b/src/common.jl
@@ -154,13 +154,13 @@ function _fit(P::Type{<:AbstractPolynomial},
     end
     R = float(T)
     if isa(deg, Integer)
-        return P{R, Symbol(var)}(R.(coeffs))
+        return P(R.(coeffs), var)
     else
         cs = zeros(T, 1 + maximum(deg))
         for (i,aᵢ) ∈ zip(deg, coeffs)
             cs[1 + i] = aᵢ
         end
-        return P{R, Symbol(var)}(cs)
+        return P(cs, var)
     end
 
 


### PR DESCRIPTION
Close issue #477 by relaxing overspecified type of polynomial returned by `fit` so that polynomial types with more that the {T,X} parameters can be fit.