### PR TITLE
Remove buggy type computation in scalar_mult.

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -1032,17 +1032,14 @@ end
 ## -- multiplication
 
 
-# this fall back not necessarily efficient (e.g., sparse)
 function scalar_mult(p::P, c::S) where {S, T, X, P<:AbstractPolynomial{T,X}}
-    R = Base.promote_op(*, T, S) # typeof(one(T)*one(S))?
-    𝐏 = ⟒(P){R,X}
-    𝐏([pᵢ * c for pᵢ ∈ coeffs(p)])
+    result = coeffs(p) .* (c,)
+    ⟒(P){eltype(result), X}(result)
 end
 
 function scalar_mult(c::S, p::P) where {S, T, X, P<:AbstractPolynomial{T, X}}
-    R = Base.promote_op(*, T, S)
-    𝐏 = ⟒(P){R,X}
-    𝐏([c * pᵢ for pᵢ ∈ coeffs(p)])
+    result = (c,) .* coeffs(p)
+    ⟒(P){eltype(result), X}(result)
 end
 
 scalar_mult(p1::AbstractPolynomial, p2::AbstractPolynomial) = error("scalar_mult(::$(typeof(p1)), ::$(typeof(p2))) is not defined.") # avoid ambiguity, issue #435


### PR DESCRIPTION
Also support efficient scalar multiplication with sparse coefficients.

Before:
```julia
using Mods, Polynomials

julia> p = Polynomial(Mod{5}[1,2,3,4])
Polynomial(Mod{5}(1) + Mod{5}(2)*x + Mod{5}(3)*x^2 + Mod{5}(4)*x^3)

julia> p ÷ (4*p)
ERROR: MethodError: no method matching one(::Type{Any})
Closest candidates are:
  one(::Type{Union{Missing, T}}) where T at missing.jl:105
  one(::Union{Type{T}, T}) where T<:AbstractString at strings/basic.jl:262
  one(::Union{Type{P}, P}) where P<:Dates.Period at ~/.local/julia-1.8.5/share/julia/stdlib/v1.8/Dates/src/periods.jl:54
  ...
Stacktrace:
 [1] one(#unused#::Type{Any})
   @ Base ./missing.jl:106
 [2] divrem(num::Polynomial{Mod{5}, :x}, den::Polynomial{Any, :x})
   @ Polynomials ~/.julia/dev/Polynomials/src/polynomials/standard-basis.jl:236
 [3] div(n::Polynomial{Mod{5}, :x}, d::Polynomial{Any, :x})
   @ Polynomials ~/.julia/dev/Polynomials/src/common.jl:1121
 [4] top-level scope
   @ REPL[4]:1
```

After:
```julia
julia> p ÷ (4*p)
Polynomial(Mod{5}(4))
```

Also, switching from comprehension to broadcasting fixes the sparse efficiency issue so I dropped the comment disclaiming that issue.

When possible, it is better to do the computation and check the type after rather than try to compute the type ahead of time. Predictive type computation is best left to the compiler.