### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ While polynomials of type `Polynomial` are mutable objects, operations such as
 `+`, `-`, `*`, always create new polynomials without modifying its arguments.
 The time needed for these allocations and copies of the polynomial coefficients
 may be noticeable in some use cases. This is amplified when the coefficients
-are for instance `BigInt` or `BigFloat` which are mutable themself.
+are for instance `BigInt` or `BigFloat` which are mutable themselves.
 This can be avoided by modifying existing polynomials to contain the result
 of the operation using the [MutableArithmetics (MA) API](https://github.com/jump-dev/MutableArithmetics.jl).
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Polynomial objects also have other methods:
 * `gcd`: greatest common divisor of two polynomials.
 
 * `Pade`: Return the
-  [Pade approximant](https://en.wikipedia.org/wiki/Pad%C3%A9_approximant) of order `m/n` for a polynomial as a `Pade` object.
+  [Padé approximant](https://en.wikipedia.org/wiki/Pad%C3%A9_approximant) of order `m/n` for a polynomial as a `Pade` object.
 
 
 ## Related Packages

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -366,7 +366,7 @@ square free polynomial. For non-square free polynomials:
 
 * The `Polynomials.Multroot.multroot` function is available  for finding the roots of a polynomial and their multiplicities. This is based on work of Zeng.
 
-Here we see `IntervalRootFinding.roots` having trouble isolating the roots due to the multiplicites:
+Here we see `IntervalRootFinding.roots` having trouble isolating the roots due to the multiplicities:
 
 ```
 julia> p = fromroots(Polynomial, [1,2,2,3,3])

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -73,7 +73,7 @@ Polynomials.@register MyPolynomial
 ```
 
 # Implementations
-This will implement simple self-conversions like `convert(::Type{MyPoly}, p::MyPoly) = p` and creates two promote rules. The first allows promotion between two types (e.g. `promote(Polynomial, ChebyshevT)`) and the second allows promotion between parametrized types (e.g. `promote(Polynomial{T}, Polynomial{S})`).
+This will implement simple self-conversions like `convert(::Type{MyPoly}, p::MyPoly) = p` and creates two promote rules. The first allows promotion between two types (e.g. `promote(Polynomial, ChebyshevT)`) and the second allows promotion between parameterized types (e.g. `promote(Polynomial{T}, Polynomial{S})`).
 
 For constructors, it implements the shortcut for `MyPoly(...) = MyPoly{T}(...)`, singleton constructor `MyPoly(x::Number, ...)`,  conversion constructor `MyPoly{T}(n::S, ...)`, and `variable` alternative  `MyPoly(var=:x)`.
 """

--- a/src/common.jl
+++ b/src/common.jl
@@ -84,7 +84,7 @@ Weights may be assigned to the points by specifying a vector or matrix of weight
 
 When specified as a vector, `[w₁,…,wₙ]`, the weights should be
 non-negative as the minimization problem is `argmin_β Σᵢ wᵢ |yᵢ - Σⱼ
-Vᵢⱼ βⱼ|² = argmin_β || √(W)⋅(y - V(x)β)||²`, where, `W` the digonal
+Vᵢⱼ βⱼ|² = argmin_β || √(W)⋅(y - V(x)β)||²`, where, `W` the diagonal
 matrix formed from `[w₁,…,wₙ]`, is used for the solution, `V` being
 the Vandermonde matrix of `x` corresponding to the specified
 degree. This parameterization of the weights is different from that of
@@ -230,7 +230,7 @@ Return the critical points of `p` (real zeros of the derivative) within `I` in s
 * `endpoints::Bool`: if `true`, return the endpoints of `I` along with the critical points
 
 
-Can be used in conjuction with `findmax`, `findmin`, `argmax`, `argmin`, `extrema`, etc.
+Can be used in conjunction with `findmax`, `findmin`, `argmax`, `argmin`, `extrema`, etc.
 
 ## Example
 ```
@@ -1110,7 +1110,7 @@ end
 return `u` the gcd of `p` and `q`, and `v` and `w`, where `u*v = p` and `u*w = q`.
 """
 uvw(p::AbstractPolynomial, q::AbstractPolynomial; kwargs...) = uvw(promote(p,q)...; kwargs...)
-uvw(p1::P, p2::P; kwargs...) where {P <:AbstractPolynomial} = throw(ArgumentError("uvw not defind"))
+uvw(p1::P, p2::P; kwargs...) where {P <:AbstractPolynomial} = throw(ArgumentError("uvw not defined"))
 
 """
     div(::AbstractPolynomial, ::AbstractPolynomial)

--- a/src/pade.jl
+++ b/src/pade.jl
@@ -22,7 +22,7 @@ export Pade
 Return Pade approximation of polynomial.
 
 # References
-[Pade Approximant](https://en.wikipedia.org/wiki/Pad%C3%A9_approximant)
+[Pade approximant](https://en.wikipedia.org/wiki/Pad%C3%A9_approximant)
 """
 struct Pade{T <: Number,S <: Number}
     p::Union{Poly{T}, Polynomial{T}}

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -22,7 +22,7 @@ As the degree of the polynomial (`+1`) is a compile-time constant,
 several performance improvements are possible. For example, immutable
 polynomials can take advantage of faster polynomial evaluation
 provided by `evalpoly` from Julia 1.4; similar methods are also used
-for addtion and multiplication.
+for addition and multiplication.
 
 However, as the degree is included in the type, promotion between
 immutable polynomials can not promote to a common type. As such, they

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -126,7 +126,7 @@ Base.promote_rule(::Type{P},::Type{Q}) where {T, X, P <: LaurentPolynomial{T,X},
 Base.promote_rule(::Type{Q},::Type{P}) where {T, X, P <: LaurentPolynomial{T,X}, S, Q <: StandardBasisPolynomial{S,X}} =
     LaurentPolynomial{promote_type(T, S),X}
 
-# need to add p.m[], so abstract.jl method isn't sufficent
+# need to add p.m[], so abstract.jl method isn't sufficient
 # XXX unlike abstract.jl, this uses Y variable in conversion; no error
 # Used in DSP.jl
 function Base.convert(::Type{LaurentPolynomial{S,Y}}, p::LaurentPolynomial{T,X}) where {T,X,S,Y}
@@ -272,7 +272,7 @@ end
 
 
 ##
-## ---- Conjugation has different defintions
+## ---- Conjugation has different definitions
 ##
 
 """

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -46,7 +46,7 @@ Base.eltype(P::Type{<:Poly{T,X}}) where {T, X} = P
 _eltype(::Type{<:Poly{T}}) where  {T} = T
 _eltype(::Type{Poly}) =  Float64
 
-# when interating over poly return monomials
+# when iterating over poly return monomials
 function Base.iterate(p::Poly, state = firstindex(p))
     firstindex(p) <= state <= lastindex(p) || return nothing
     return p[state] * Polynomials.basis(p,state), state+1

--- a/src/polynomials/factored_polynomial.jl
+++ b/src/polynomials/factored_polynomial.jl
@@ -58,7 +58,7 @@ struct FactoredPolynomial{T <: Number, X} <: StandardBasisPolynomial{T, X}
     end
 end
 
-# There are idiosyncracies with this type
+# There are idiosyncrasies with this type
 # * unlike P{T}(...) we allow T to widen here if the roots of the polynomial Polynomial(coeffs) needs
 #   a wider type (e.g. Complex{Float64}, not Float64)
 # * the handling of Inf and NaN, when a specified coefficient, is to just return a constant poly (Inf or NaN)

--- a/src/polynomials/multroot.jl
+++ b/src/polynomials/multroot.jl
@@ -167,7 +167,7 @@ end
 
 Find a *pejorative* *root* for `p` given multiplicity structure `ls` and initial guess `zs`.
 
-The pejorative manifold for a multplicity structure `l` is denoted `{Gₗ(z) | z ∈ Cᵐ}`. A pejorative
+The pejorative manifold for a multiplicity structure `l` is denoted `{Gₗ(z) | z ∈ Cᵐ}`. A pejorative
 root is a least squares minimizer of `F(z) = W ⋅ [Gₗ(z) - a]`. Here `a ~ (p_{n-1}, p_{n-2}, …, p_1, p_0) / p_n` and `W` are weights given by `min(1, 1/|aᵢ|)`. When `l` is the mathematically correct structure, then `F` will be `0` for a pejorative root. If `l` is not correct, then the backward error `‖p̃ - p‖_w` is typically large, where `p̃ = Π (x-z̃ᵢ)ˡⁱ`.
 
 This follows Algorithm 1 of [Zeng](https://www.ams.org/journals/mcom/2005-74-250/S0025-5718-04-01692-8/S0025-5718-04-01692-8.pdf)

--- a/src/polynomials/ngcd.jl
+++ b/src/polynomials/ngcd.jl
@@ -127,7 +127,7 @@ which ``Θᵏ < ϵ``.
 (In the ``ϵ → 0`` limit, this would be the exact GCD.)
 
 
-Suppose ``(p,q)`` is an ``ϵ`` pertubation from ``(p̂,q̂)`` where ``(p̂,q̂)`` has an exact gcd of degree ``k``, then ``degree(gcdₑ(p,q)) = k``; as ``ϵ → 0``, ``gcdₑ(p,q) → gcd(p̂, q̂)``, and
+Suppose ``(p,q)`` is an ``ϵ`` perturbation from ``(p̂,q̂)`` where ``(p̂,q̂)`` has an exact gcd of degree ``k``, then ``degree(gcdₑ(p,q)) = k``; as ``ϵ → 0``, ``gcdₑ(p,q) → gcd(p̂, q̂)``, and
 
 ``\\limsup_{(p,q)→(p̂,q̂)} \\inf{ ‖ (u,v,w) - (û,v̂,ŵ) ‖} / ‖ (p,q) - (p̂,q̂) ‖ < κₑ(p,q)``.
 
@@ -387,7 +387,7 @@ function smallest_singular_value!(w, R::UpperTriangular{T},
 
 end
 
-# no tolerance; stop when improvment stops
+# no tolerance; stop when improvement stops
 function smallest_singular_value(A)
     R = UpperTriangular(qr(A).R)
     w = Vector{eltype(R)}(undef, size(R, 2))
@@ -488,7 +488,7 @@ end
 
 
 # extend QR to next size
-# Q gets a 1 in nc,nc, 0s should be elswhere
+# Q gets a 1 in nc,nc, 0s should be elsewhere
 function extend_QR!(Q, R, nr, nc, A0)
 
     #old Q is m x m, old R is n x n; we add to these

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -87,7 +87,7 @@ function ⊗(P::Type{<:StandardBasisPolynomial}, p::Vector{T}, q::Vector{S}) whe
     fastconv(convert(Vector{R}, p), convert(Vector{R},q))
 end
 
-## put here, not with type defintion, in case reuse is possible
+## put here, not with type definition, in case reuse is possible
 ## `conv` can be used with matrix entries, unlike `fastconv`
 function conv(p::Vector{T}, q::Vector{S}) where {T,S}
     as = [p[1]*q[1]]
@@ -824,7 +824,7 @@ end
 
 # Condition number of a standard basis polynomial
 # rule of thumb: p̂ a compute value
-# |p(x) - p̃(x)|/|p(x)| ≤ α(n)⋅u ⋅ cond(p,x), where u = finite precision of compuation (2^-p)
+# |p(x) - p̃(x)|/|p(x)| ≤ α(n)⋅u ⋅ cond(p,x), where u = finite precision of computation (2^-p)
 function LinearAlgebra.cond(p::P, x) where {P <: StandardBasisPolynomial}
     p̃ = map(abs, p)
     p̃(abs(x))/ abs(p(x))

--- a/src/rational-functions/fit.jl
+++ b/src/rational-functions/fit.jl
@@ -130,7 +130,7 @@ function pade_fit(p::Polynomial{T}, m::Integer, n::Integer; var=:x) where {T}
     d = degree(p)
     @assert (0 <= m) && (1 <= n) && (m + n <= d)
 
-    # could be much more perfomant
+    # could be much more performant
     c = convert(LaurentPolynomial, p) # for better indexing
     cs = [c[m+j-i] for j ∈ 1:n, i ∈ 0:n]
 

--- a/src/rational-functions/plot-recipes.jl
+++ b/src/rational-functions/plot-recipes.jl
@@ -1,6 +1,6 @@
 ## Plot recipe
 ## define a hueristic to work around asymptotes
-## just sort of succesful
+## just sort of successful
 @recipe function f(pq::AbstractRationalFunction{T}, a=nothing, b=nothing) where {T}
 
     xlims = get(plotattributes, :xlims, (nothing, nothing))

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -128,7 +128,7 @@ Base.getindex(z::ZVector, I::Int) = parent(z)[I + z.offset]
         @test iszero(p0)
         P != LaurentPolynomial && @test degree(p0) == -1
 
-        # P(2) is  2 (not  2p₀)  connvert(Polynomial, P(s::Number)) = Polynomial(s)
+        # P(2) is  2 (not  2p₀)  convert(Polynomial, P(s::Number)) = Polynomial(s)
         @test convert(Polynomial, P(2)) ≈ Polynomial(2)
         @test P(2)  ≈ 2*one(P)
 
@@ -1145,7 +1145,7 @@ end
         end
 
         # * Promotion can be forced to mix constant-polynomials
-        @testset "Use typed constructor to mix constant polynomals" begin
+        @testset "Use typed constructor to mix constant polynomials" begin
             𝑷,𝑸 = P{Int,:x}, P{Int,:y} # not typeof(p),... as Immutable carries N
             @test_throws ArgumentError [one(p), one(q)]
             @test eltype(𝑷[one(p), one(q)]) == 𝑷


### PR DESCRIPTION
README.md
docs/src/index.md
src/common.jl
src/pade.jl
src/polynomials/ImmutablePolynomial.jl
src/polynomials/LaurentPolynomial.jl
src/polynomials/Poly.jl
src/polynomials/factored_polynomial.jl
src/polynomials/multroot.jl
src/polynomials/ngcd.jl
src/polynomials/standard-basis.jl
src/rational-functions/fit.jl
src/rational-functions/plot-recipes.jl
test/StandardBasis.jl

it's possible to add these

```
$ ed -s Polynomials.jl/README.md <<<'290,291p'
* `Pade`: Return the
  [Pade approximant](https://en.wikipedia.org/wiki/Pad%C3%A9_approximant) of order `m/n` for a polynomial as a `Pade` object.
$ 
```

`sed -i "s/Pade approximant/Padé approximant/g" Polynomials.jl/README.md`

this isn't a typo but is more standard

`sed -i "s/parametrized/parameterized/g" Polynomials.jl/src/abstract.jl`