### PR TITLE
Eltype fix; use T[] for 0-polynomial; speed up LaurentPolynomial operations

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -79,7 +79,7 @@ vander
 
 ## Plotting
 
-Polynomials can be plotted directly using [Plots.jl](https://github.com/juliaplots/plots.jl).
+Polynomials can be plotted directly using [Plots.jl](https://github.com/juliaplots/plots.jl) or [Makie.jl](https://github.com/MakieOrg/Makie.jl).
 
 ```julia
 plot(::AbstractPolynomial; kwds...)

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -30,8 +30,8 @@ Some `T`s will not be successful
 * scalar mult: `c::T * p::Polynomial{T}` An  ambiguity when `T <: AbstractPolynomial`
 * scalar mult: `p::Polynomial{T} * c::T` need not commute
 
-* scalar add/sub: `p::Polynomial{T} + q::Polynomial{T}` should be defined
-* scalar sub: `p::Polynomial{T} - p::Polynomial{T}`  generally needs `zeros(T,1)` defined for `zero(Polynomial{T})`
+* add/sub: `p::Polynomial{T} + q::Polynomial{T}` should be defined
+* sub: `p -p` sometimes needs `zero{T}` defined
 
 * poly mult: `p::Polynomial{T} * q::Polynomial{T}` Needs "`T * T`" defined (e.g. `Base.promote_op(*, Vector{Int}, Vector{Int}))` needs to be something.)
 * poly powers: `p::Polynomial{T}^2` needs "`T^2`" defined
@@ -41,6 +41,7 @@ Some `T`s will not be successful
 
 * evaluation: `p::Polynomial{T}(s::Number)`
 * evaluation `p::Polynomial{T}(c::T)`   needs `T*T` defined
+* evaluation of a `0` polynomial requires `zero(T)` to be defined.
 
 * derivatives: `derivative(p::Polynomial{T})`
 * integrals: `integrate(p::Polynomial{T})`

--- a/src/contrib.jl
+++ b/src/contrib.jl
@@ -132,12 +132,6 @@ function _zero(x::Matrix)
 end
 _zero(x) = zero(x)
 
-function _eltype(x, n=1)
-    T = eltype(x)
-    eltype(T) == T && return T
-    n > 10 && throw(DomainError())
-    _eltype(T, n+1)
-end
 end
 
 ## get type of parametric composite type without type parameters

--- a/src/contrib.jl
+++ b/src/contrib.jl
@@ -5,6 +5,8 @@ using Base.Cartesian
 
 # direct version (do not check if threshold is satisfied)
 function fastconv(E::Array{T,N}, k::Array{T,N}) where {T,N}
+    isempty(E) && return E
+    isempty(k) && return k
     retsize = ntuple(n -> size(E, n) + size(k, n) - 1, Val{N}())
     ret = zeros(T, retsize)
     convn!(ret, E, k)
@@ -52,7 +54,7 @@ evalpoly(x, p::AbstractVector) = _evalpoly(x, p)
 # https://discourse.julialang.org/t/i-have-a-much-faster-version-of-evalpoly-why-is-it-faster/79899; improvement *and* closes #313
 function _evalpoly(x::S, p) where {S}
     i = lastindex(p)
-
+    iszero(i) && return zero(eltype(p))*_one(x)
     @inbounds out = p[i]*_one(x)
     i -= 1
 

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -154,7 +154,7 @@ function vander(P::Type{<:ChebyshevT}, x::AbstractVector{T}, n::Integer) where {
 end
 
 function integrate(p::ChebyshevT{T,X}) where {T,X}
-    R = eltype(one(T) / 1)
+    R = eltype(one(T) / one(T))
     Q = ChebyshevT{R,X}
     if hasnan(p)
         return Q([NaN])

--- a/src/polynomials/ChebyshevT.jl
+++ b/src/polynomials/ChebyshevT.jl
@@ -154,7 +154,7 @@ function vander(P::Type{<:ChebyshevT}, x::AbstractVector{T}, n::Integer) where {
 end
 
 function integrate(p::ChebyshevT{T,X}) where {T,X}
-    R = eltype(one(T) / one(T))
+    R = eltype(one(T) / 1)
     Q = ChebyshevT{R,X}
     if hasnan(p)
         return Q([NaN])

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -188,43 +188,35 @@ function Base.:+(p1::P, p2::Q) where {T,X,N,P<:ImmutablePolynomial{T,X,N},
 end
 
 ## multiplication
-
 function scalar_mult(p::ImmutablePolynomial{T,X,N}, c::S) where {T, X,N, S <: Number}
-    R′ = promote_type(T,S)
-    iszero(N) && return zero(ImmutablePolynomial{R′,X})
-    iszero(c) && ImmutablePolynomial([p[0] .* c], X)
-    cs = p.coeffs .* c
-    R = eltype(cs)
-    P = ImmutablePolynomial{R,X}
-
-    iszero(cs[end]) ? P(cs) : P{N}(cs)
+    iszero(N) && return zero(ImmutablePolynomial{promote_type(T,S),X})
+    iszero(c) && ImmutablePolynomial([p[0] .* (c,)], X)
+    return _polynomial(p, p.coeffs .* (c,))
 end
 
 function scalar_mult(c::S, p::ImmutablePolynomial{T,X,N}) where {T, X,N, S <: Number}
-    R′ = promote_type(T,S)
-    iszero(N) && return zero(ImmutablePolynomial{R′,X})
-    iszero(c) && ImmutablePolynomial([c .* p[0]], X)
-    cs = c .* p.coeffs
+    iszero(N) && return zero(ImmutablePolynomial{promote_type(T,S),X})
+    iszero(c) && ImmutablePolynomial([(c,) .* p[0]], X)
+    return _polynomial(p, (c,) .* p.coeffs)
+end
+
+function _polynomial(p::ImmutablePolynomial{T,X,N}, cs) where {T, X, N}
     R = eltype(cs)
     P = ImmutablePolynomial{R,X}
     iszero(cs[end]) ? P(cs) : P{N}(cs)
 end
 
-
-
 function Base.:*(p1::ImmutablePolynomial{T,X,N}, p2::ImmutablePolynomial{S,X,M}) where {T,S,X,N,M}
-    R = promote_type(T,S)
-    P = ImmutablePolynomial{R,X}
-
-    (iszero(N) || iszero(M)) && return zero(P)
+    (iszero(N) || iszero(M)) && return zero(ImmutablePolynomial{promote_type(T,S),X})
 
     cs = ⊗(ImmutablePolynomial, p1.coeffs, p2.coeffs) #(p1.coeffs) ⊗ (p2.coeffs)
+    R = eltype(cs)
+    P = ImmutablePolynomial{R,X}
     iszero(cs[end]) ? P(cs) : P{N+M-1}(cs)  # more performant to specify when N is known
 
 end
 
 Base.to_power_type(p::ImmutablePolynomial{T,X,N}) where {T,X,N} = p
-
 
 ## more performant versions borrowed from StaticArrays
 ## https://github.com/JuliaArrays/StaticArrays.jl/blob/master/src/linalg.jl

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -190,13 +190,13 @@ end
 ## multiplication
 function scalar_mult(p::ImmutablePolynomial{T,X,N}, c::S) where {T, X,N, S <: Number}
     iszero(N) && return zero(ImmutablePolynomial{promote_type(T,S),X})
-    iszero(c) && ImmutablePolynomial([p[0] .* (c,)], X)
+    iszero(c) && ImmutablePolynomial([p[0] .* c], X)
     return _polynomial(p, p.coeffs .* (c,))
 end
 
 function scalar_mult(c::S, p::ImmutablePolynomial{T,X,N}) where {T, X,N, S <: Number}
     iszero(N) && return zero(ImmutablePolynomial{promote_type(T,S),X})
-    iszero(c) && ImmutablePolynomial([(c,) .* p[0]], X)
+    iszero(c) && ImmutablePolynomial([c .* p[0]], X)
     return _polynomial(p, (c,) .* p.coeffs)
 end
 

--- a/src/polynomials/ImmutablePolynomial.jl
+++ b/src/polynomials/ImmutablePolynomial.jl
@@ -64,7 +64,7 @@ end
 
 ## Various interfaces
 ## Abstract Vector coefficients
-function ImmutablePolynomial{T,X, N}(coeffs::AbstractVector{T})  where {T,X, N}
+function ImmutablePolynomial{T, X, N}(coeffs::AbstractVector{T})  where {T,X, N}
     cs = NTuple{N,T}(coeffs[i] for i ∈ firstindex(coeffs):N)
     ImmutablePolynomial{T, X, N}(cs)
 
@@ -190,26 +190,26 @@ end
 ## multiplication
 
 function scalar_mult(p::ImmutablePolynomial{T,X,N}, c::S) where {T, X,N, S <: Number}
-    R = eltype(p[0] * c * 0)
-    (N == 0  || iszero(c)) && return zero(ImmutablePolynomial{R,X})
+    R′ = promote_type(T,S)
+    iszero(N) && return zero(ImmutablePolynomial{R′,X})
+    iszero(c) && ImmutablePolynomial([p[0] .* c], X)
     cs = p.coeffs .* c
-    return ImmutablePolynomial(cs, X)
- end
+    R = eltype(cs)
+    P = ImmutablePolynomial{R,X}
+
+    iszero(cs[end]) ? P(cs) : P{N}(cs)
+end
 
 function scalar_mult(c::S, p::ImmutablePolynomial{T,X,N}) where {T, X,N, S <: Number}
-    R = eltype(p[0] * c * 0)
-    (N == 0  || iszero(c)) && return zero(ImmutablePolynomial{R,X})
-    cs = p.coeffs .* c
-    return ImmutablePolynomial(cs, X)
+    R′ = promote_type(T,S)
+    iszero(N) && return zero(ImmutablePolynomial{R′,X})
+    iszero(c) && ImmutablePolynomial([c .* p[0]], X)
+    cs = c .* p.coeffs
+    R = eltype(cs)
+    P = ImmutablePolynomial{R,X}
+    iszero(cs[end]) ? P(cs) : P{N}(cs)
 end
 
-function Base.:/(p::ImmutablePolynomial{T,X,N}, c::S) where {T,X,N,S<:Number}
-    R = eltype(one(T)/one(S))
-    P = ImmutablePolynomial{R,X}
-    (N == 0  || isinf(c)) && return zero(P)
-    cs = p.coeffs ./ c
-    iszero(cs[end]) ? P(cs) : P{N}(cs) # more performant to specify when N is known
-end
 
 
 function Base.:*(p1::ImmutablePolynomial{T,X,N}, p2::ImmutablePolynomial{S,X,M}) where {T,S,X,N,M}

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -511,8 +511,8 @@ end
 
 
 function integrate(p::P) where {T, X, P <: LaurentBasisPolynomial{T, X}}
-    T′ = eltype(T)
-    R = typeof(constantterm(p) / one(T′))
+
+    R = typeof(constantterm(p) / 1)
     Q = ⟒(P){R,X}
 
     hasnan(p) && return Q([NaN])
@@ -522,7 +522,7 @@ function integrate(p::P) where {T, X, P <: LaurentBasisPolynomial{T, X}}
     for (k, pₖ) ∈ pairs(p)
         iszero(pₖ) && continue
         k == -1 && throw(ArgumentError("Can't integrate Laurent polynomial with  `x⁻¹` term"))
-        ∫p[k+1] = pₖ/T′(k+1)
+        ∫p[k+1] = pₖ/(k+1)
     end
     ∫p
 end

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -1,5 +1,6 @@
 export LaurentPolynomial
 
+
 """
     LaurentPolynomial{T,X}(coeffs::AbstractVector, [m::Integer = 0], [var = :x])
 
@@ -93,6 +94,11 @@ struct LaurentPolynomial{T, X} <: LaurentBasisPolynomial{T, X}
             (n - m′ + 1  == length(c)) || throw(ArgumentError("Lengths do not match"))
             new{T,X}(c, Ref(m′),  Ref(n))
         end
+    end
+    # non copying version assumes trimmed coeffs
+    function LaurentPolynomial{T,X}(::Val{false}, coeffs::AbstractVector{T},
+                                    m::Integer=0) where {T, X}
+        new{T,X}(coeffs, Ref(m), Ref(m + length(coeffs) - 1))
     end
 end
 
@@ -259,7 +265,7 @@ end
 function showterm(io::IO, ::Type{<:LaurentPolynomial}, pj::T, var, j, first::Bool, mimetype) where {T}
     if iszero(pj) return false end
     pj = printsign(io, pj, first, mimetype)
-    if !(pj == one(T) && !(showone(T) || j == 0))
+    if !(hasone(T) && pj == one(T) && !(showone(T) || j == 0))
         printcoefficient(io, pj, j, mimetype)
     end
     printproductsign(io, pj, j, mimetype)
@@ -413,48 +419,87 @@ function Base.:+(p::LaurentPolynomial{T,X}, c::S) where {T, X, S <: Number}
 end
 
 ##
-## Poly + and  *
-##
-function Base.:+(p1::P, p2::P) where {T,X,P<:LaurentPolynomial{T,X}}
+## Poly +, - and  *
+## uses some ideas from https://github.com/jmichel7/LaurentPolynomials.jl/blob/main/src/LaurentPolynomials.jl for speedups
+Base.:+(p1::LaurentPolynomial, p2::LaurentPolynomial) = add_sub(+, p1, p2)
+Base.:-(p1::LaurentPolynomial, p2::LaurentPolynomial) = add_sub(-, p1, p2)
 
-    isconstant(p1) && return constantterm(p1) + p2
-    isconstant(p2) && return p1 + constantterm(p2)
+function add_sub(op, p1::P, p2::Q) where {T, X, P <: LaurentPolynomial{T,X},
+                                          S, Y, Q <: LaurentPolynomial{S,Y}}
 
+    isconstant(p1) && return op(constantterm(p1), p2)
+    isconstant(p2) && return op(p1, constantterm(p2))
+    assert_same_variable(X, Y)
 
     m1,n1 = (extrema ∘ degreerange)(p1)
     m2,n2 = (extrema ∘ degreerange)(p2)
-    m,n = min(m1,m2), max(n1, n2)
+    m, n = min(m1,m2), max(n1, n2)
 
-    as = zeros(T, length(m:n))
-    for i in m:n
-        as[1 + i-m] = p1[i] + p2[i]
+    R = promote_type(T,S)
+    as = zeros(R, length(m:n))
+
+    d = m1 - m2
+    d1, d2 = m1 > m2 ? (d,0) : (0, -d)
+
+    for (i, pᵢ) ∈ pairs(p1.coeffs)
+        @inbounds as[d1 + i] = pᵢ
+    end
+    for (i, pᵢ) ∈ pairs(p2.coeffs)
+        @inbounds as[d2 + i] = op(as[d2+i], pᵢ)
     end
 
-    q = P(as, m)
-    chop!(q)
-
+    m = _laurent_chop!(as, m)
+    isempty(as) && return zero(LaurentPolynomial{R,X})
+    q = LaurentPolynomial{R,X}(Val(false), as, m)
     return q
 
 end
 
-function Base.:*(p1::P, p2::P) where {T,X,P<:LaurentPolynomial{T,X}}
+function Base.:*(p1::P, p2::Q) where {T,X,P<:LaurentPolynomial{T,X},
+                                      S,Y,Q<:LaurentPolynomial{S,Y}}
+
+    isconstant(p1) && return constantterm(p1) * p2
+    isconstant(p2) && return p1 * constantterm(p2)
+    assert_same_variable(X, Y)
 
     m1,n1 = (extrema ∘ degreerange)(p1)
     m2,n2 = (extrema ∘ degreerange)(p2)
     m,n = m1 + m2, n1+n2
 
-    as = zeros(T, length(m:n))
-    for i in eachindex(p1)
-        p1ᵢ = p1[i]
-        for j in eachindex(p2)
-            as[1 + i+j - m] = muladd(p1ᵢ, p2[j], as[1 + i + j - m])
+    R = promote_type(T,S)
+    as = zeros(R, length(m:n))
+
+    for (i, p₁ᵢ) ∈ pairs(p1.coeffs)
+        for (j, p₂ⱼ) ∈ pairs(p2.coeffs)
+            @inbounds as[i+j-1] += p₁ᵢ * p₂ⱼ
         end
     end
 
-    p = P(as, m)
-    chop!(p)
+    m = _laurent_chop!(as, m)
+
+    isempty(as) && return zero(LaurentPolynomial{R,X})
+    p = LaurentPolynomial{R,X}(Val(false), as, m)
 
     return p
+end
+
+function _laurent_chop!(as, m)
+    while !isempty(as)
+        if iszero(first(as))
+            m += 1
+            popfirst!(as)
+        else
+            break
+        end
+    end
+    while !isempty(as)
+        if iszero(last(as))
+            pop!(as)
+        else
+            break
+        end
+    end
+    m
 end
 
 function scalar_mult(p::LaurentPolynomial{T,X}, c::Number) where {T,X}
@@ -462,6 +507,24 @@ function scalar_mult(p::LaurentPolynomial{T,X}, c::Number) where {T,X}
 end
 function scalar_mult(c::Number, p::LaurentPolynomial{T,X}) where {T,X}
     LaurentPolynomial(c .* p.coeffs, p.m[], Var(X))
+end
+
+
+function integrate(p::P) where {T, X, P <: LaurentBasisPolynomial{T, X}}
+    T′ = eltype(T)
+    R = typeof(constantterm(p) / one(T′))
+    Q = ⟒(P){R,X}
+
+    hasnan(p) && return Q([NaN])
+    iszero(p) && return zero(Q)
+
+    ∫p = zero(Q)
+    for (k, pₖ) ∈ pairs(p)
+        iszero(pₖ) && continue
+        k == -1 && throw(ArgumentError("Can't integrate Laurent polynomial with  `x⁻¹` term"))
+        ∫p[k+1] = pₖ/T′(k+1)
+    end
+    ∫p
 end
 
 ##

--- a/src/polynomials/LaurentPolynomial.jl
+++ b/src/polynomials/LaurentPolynomial.jl
@@ -435,7 +435,7 @@ function add_sub(op, p1::P, p2::Q) where {T, X, P <: LaurentPolynomial{T,X},
     m2,n2 = (extrema ∘ degreerange)(p2)
     m, n = min(m1,m2), max(n1, n2)
 
-    R = promote_type(T,S)
+    R = typeof(p1.coeffs[1] + p2.coeffs[1]) # non-empty
     as = zeros(R, length(m:n))
 
     d = m1 - m2

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -116,7 +116,7 @@ end
 
 function Polynomials.integrate(p::P, k::S) where {T, X, P <: Poly{T, X}, S<:Number}
 
-    R = eltype((one(T)+one(S))/1)
+    R = eltype(one(T)/one(T)+one(S))
     Q = Poly{R,X}
     if hasnan(p) || isnan(k)
         return P([NaN]) # keep for Poly, not Q

--- a/src/polynomials/Poly.jl
+++ b/src/polynomials/Poly.jl
@@ -116,7 +116,7 @@ end
 
 function Polynomials.integrate(p::P, k::S) where {T, X, P <: Poly{T, X}, S<:Number}
 
-    R = eltype(one(T)/one(T)+one(S))
+    R = eltype(one(T)/1 + one(S))
     Q = Poly{R,X}
     if hasnan(p) || isnan(k)
         return P([NaN]) # keep for Poly, not Q

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -212,15 +212,9 @@ end
 
 function scalar_mult(c::S, p::P) where {T, X, P <: SparsePolynomial{T,X}, S<:Number}
 
-    R1 = promote_type(T,S)
-    R = typeof(zero(c)*zero(T))
-    Q = ⟒(P){R,X}
-    q = zero(Q)
-    for (k,pₖ) ∈ pairs(p)
-        q[k] = c * pₖ
-    end
-
-    return q
+    vs = (c,) .* values(p)
+    d = Dict(k=>v for (k,v) ∈ zip(keys(p), vs))
+    return SparsePolynomial{eltype(vs), X}(d)
 end
 
 function Base.:*(p::P, q::Q) where {T,X,P<:SparsePolynomial{T,X},

--- a/src/polynomials/SparsePolynomial.jl
+++ b/src/polynomials/SparsePolynomial.jl
@@ -145,7 +145,7 @@ end
 
 function evalpoly(x::S, p::SparsePolynomial{T}) where {T,S}
 
-    tot = zero(T) * EvalPoly._one(x)
+    tot = zero(x*p[0])
     for (k,v) in p.coeffs
         tot = EvalPoly._muladd(x^k, v, tot)
     end
@@ -165,32 +165,34 @@ end
 ## Addition
 function Base.:+(p::SparsePolynomial{T,X}, c::S) where {T, X, S <: Number}
 
-    R = promote_type(T,S)
+    c₀ = p[0] + c
+    R = eltype(c₀)
+
+    D = convert(Dict{Int, R}, copy(p.coeffs))
+    !iszero(c₀) && (@inbounds D[0] = c₀)
+
     P = SparsePolynomial{R,X}
-
-    #D = Dict{Int, R}(kv for kv ∈ p.coeffs)
-    D = Dict{Int, R}()
-    for (k,v) ∈ pairs(p)
-        @inbounds D[k] = v
-    end
-    @inbounds D[0] = get(D,0,zero(R)) + c
-    iszero(D[0]) && pop!(D,0)
-
-    return P(Val(false), D)
-
+    length(keys(D)) > 0 ? P(Val(false), D) : zero(P)
 end
 
-# Implement over fallback. A bit faster as it covers T != S
-function Base.:+(p1::P1, p2::P2) where {T,X, P1<:SparsePolynomial{T,X},
-                                        S,   P2<:SparsePolynomial{S,X}}
+# much faster than default
+function Base.:+(p1::P1, p2::P2) where {T, X, P1<:SparsePolynomial{T,X},
+                                        S,    P2<:SparsePolynomial{S,X}}
 
     R = promote_type(T,S)
-    Q = SparsePolynomial{R,X}
+    D = convert(Dict{Int,R}, copy(p1.coeffs))
+    for (i, pᵢ) ∈  pairs(p2.coeffs)
+        qᵢ =  get(D, i, zero(R))
+        pqᵢ = pᵢ + qᵢ
+        if iszero(pqᵢ)
+            pop!(D,i) # will be zero
+        else
+            D[i] = pᵢ + qᵢ
+        end
+    end
 
-    d1, d2 = degree(p1), degree(p2)
-    cs = d1 > d2 ? ⊕(P1, p1.coeffs, p2.coeffs) : ⊕(P1, p2.coeffs, p1.coeffs)
-
-    return d1 != d2 ? Q(Val(false), cs) : Q(cs)
+    P = SparsePolynomial{R,X}
+    isempty(keys(D)) ? zero(P) : P(Val(false), D)
 
 end
 
@@ -198,6 +200,16 @@ Base.:-(a::SparsePolynomial) = typeof(a)(Dict(k=>-v for (k,v) in a.coeffs))
 
 ## Multiplication
 function scalar_mult(p::P, c::S) where {T, X, P <: SparsePolynomial{T,X}, S<:Number}
+
+    R = promote_type(T,S)
+    iszero(c) && return(zero(SparsePolynomial{R,X}))
+
+    d = convert(Dict{Int, R}, copy(p.coeffs))
+    for (k, pₖ) ∈ pairs(d)
+        @inbounds d[k] = d[k] .* c
+    end
+    return SparsePolynomial{R,X}(Val(false), d)
+
 
     R1 = promote_type(T,S)
     R = typeof(zero(c)*zero(T))
@@ -212,16 +224,20 @@ end
 
 function scalar_mult(c::S, p::P) where {T, X, P <: SparsePolynomial{T,X}, S<:Number}
 
+    R = promote_type(T,S)
+    iszero(c) && return(zero(SparsePolynomial{R,X}))
+
+    d = convert(Dict{Int, R}, copy(p.coeffs))
+    for (k, pₖ) ∈ pairs(d)
+        @inbounds d[k] = c .* d[k]
+    end
+    return SparsePolynomial{R,X}(Val(false), d)
+
     vs = (c,) .* values(p)
     d = Dict(k=>v for (k,v) ∈ zip(keys(p), vs))
     return SparsePolynomial{eltype(vs), X}(d)
 end
 
-function Base.:*(p::P, q::Q) where {T,X,P<:SparsePolynomial{T,X},
-                                    S,  Q<:SparsePolynomial{S,X}}
-    R = promote_type(T,S)
-    SparsePolynomial{R,X}(⊗(P, p.coeffs, q.coeffs))
-end
 
 
 function derivative(p::SparsePolynomial{T,X}, order::Integer = 1) where {T,X}
@@ -229,7 +245,7 @@ function derivative(p::SparsePolynomial{T,X}, order::Integer = 1) where {T,X}
     order < 0 && throw(ArgumentError("Order of derivative must be non-negative"))
     order == 0 && return p
 
-    R = eltype(one(T)*1)
+    R = eltype(p[0]*1)
     P = SparsePolynomial
     hasnan(p) && return P{R,X}(Dict(0 => R(NaN)))
 

--- a/src/polynomials/factored_polynomial.jl
+++ b/src/polynomials/factored_polynomial.jl
@@ -175,6 +175,8 @@ function Base.getindex(p::FactoredPolynomial{T}, idx::Int) where {T <: Number}
     coeffs(p)[idx - m + 1]
 end
 
+Base.setindex!(p::FactoredPolynomial, val,  idx::Int) = throw(ArgumentError("FactoredPolynomials are immutable"))
+
 # pairs,keys, values
 Base.keys(p::FactoredPolynomial)   = keys(convert(Polynomial, p))
 Base.values(p::FactoredPolynomial) = values(convert(Polynomial, p))
@@ -276,6 +278,7 @@ function scalar_mult(p::P, c::S) where {S<:Number, T, X, P <: FactoredPolynomial
     copy!(d, p.coeffs)
     FactoredPolynomial{R,X}(d, c * p.c)
 end
+scalar_mult(c::S, p::P) where {S<:Number, T, X, P <: FactoredPolynomial{T, X}} = scalar_mult(p, c) # assume commutative, as we have S <: Number
 
 # scalar division
 function Base.:/(p::P, c::S) where {S<:Number, T, X, P <: FactoredPolynomial{T, X}}

--- a/src/polynomials/pi_n_polynomial.jl
+++ b/src/polynomials/pi_n_polynomial.jl
@@ -41,6 +41,15 @@ function degree(p::PnPolynomial)
 end
 
 # pre-allocated multiplication
+function LinearAlgebra.lmul!(c::Number, p::PnPolynomial{T,X}) where {T,X}
+    p.coeffs[:] = (c,) .* p.coeffs
+    p
+end
+function LinearAlgebra.rmul!(p::PnPolynomial{T,X}, c::Number) where {T,X}
+    p.coeffs[:] = p.coeffs .* (c,)
+    p
+end
+
 function LinearAlgebra.mul!(pq, p::PnPolynomial{T,X}, q) where {T,X}
     m,n = length(p)-1, length(q)-1
     pq.coeffs .= zero(T)

--- a/src/polynomials/pi_n_polynomial.jl
+++ b/src/polynomials/pi_n_polynomial.jl
@@ -24,7 +24,7 @@ end
 PnPolynomial{T, X}(coeffs::Tuple) where {T, X} =
     PnPolynomial{T,X}(T[pᵢ for pᵢ ∈ coeffs])
 
-Polynomials.@register PnPolynomial
+@register PnPolynomial
 
 # change broadcast semantics
 Base.broadcastable(p::PnPolynomial) = p.coeffs;
@@ -34,7 +34,7 @@ Base.copyto!(p::PnPolynomial{T, X}, x::S) where
  S<:Union{AbstractVector, Base.AbstractBroadcasted, Tuple} # to avoid an invalidation. Might need to be more general?
  } = copyto!(p.coeffs, x)
 
-function Polynomials.degree(p::PnPolynomial)
+function degree(p::PnPolynomial)
     i = findlast(!iszero, p.coeffs)
     isnothing(i) && return -1
     i - 1

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -7,7 +7,11 @@ function showterm(io::IO, ::Type{<:StandardBasisPolynomial}, pj::T, var, j, firs
 
     pj = printsign(io, pj, first, mimetype)
 
-    if !(_isone(pj) && !(showone(T) || j == 0))
+    if hasone(T)
+        if !(_isone(pj) && !(showone(T) || j == 0))
+            printcoefficient(io, pj, j, mimetype)
+        end
+    else
         printcoefficient(io, pj, j, mimetype)
     end
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -21,6 +21,10 @@ isneg(pj::T) where {T} = hasneg(T) && _isone(sign(-pj))
 "Make `pj` positive if it is negative. (Don't call `abs` as that may not be defined, or appropriate.)"
 aspos(pj::T) where {T} = (hasneg(T) && isneg(pj)) ? -pj : pj
 
+"does type T have a 1?"
+hasone(::Type{<:Number}) = true
+hasone(::Type{T}) where {T} = false
+
 "Should a value of `one(T)` be shown as a coefficient of monomial `x^i`, `i >= 1`? (`1.0x^2` is shown, `1 x^2` is not)"
 showone(::Type{T}) where {T} = true
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -152,7 +152,7 @@ function printpoly(io::IO, p::P, mimetype=MIME"text/plain"();
         first &= !printed
         printed_anything |= printed
     end
-    printed_anything || print(io, zero(T))
+    printed_anything || print(io, zero(eltype(T)))
     return nothing
 end
 

--- a/test/Poly.jl
+++ b/test/Poly.jl
@@ -72,7 +72,7 @@ sprint(show, pNULL)
 
 @test p3 == Poly([1,2,1])
 @test pN*10 == Poly([2760, 30, 870, 150, 240])
-@test pN/10 == Poly([27.6, 0.3, 8.7, 1.5, 2.4])
+@test pN/10 ≈ Poly([27.6, 0.3, 8.7, 1.5, 2.4])
 @test 10*pNULL + pN == pN
 @test 10*p0 + pN == pN
 @test p5 + 2*p1 == Poly([3,4,6,4,1])

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -228,7 +228,7 @@ end
             @test +p == p
             @test p + q == P([a+a,b+b,c])
             @test p - q == P([a-a,b-b,c])
-            @test_throws MethodError p - p == P([0*a])  # no zeros to make zero polynomial
+#            @test_throws MethodError p - p == P([0*a])  # no zeros to make zero polynomial
 
             # poly mult
             @test p * q == P(conv([a,b,c], [a,b]))
@@ -278,7 +278,7 @@ end
             @test +p == p
             @test p + q == P([a+a,b+b,c])
             @test p - q == P([a-a,b-b,c])
-            @test_throws MethodError p - p == P([0*a])  # no zero(T) to make zero polynomial
+##            @test_throws MethodError p - p == P([0*a])  # no zero(T) to make zero polynomial
 
             # poly mult
             @test_throws MethodError p * q == P(conv([a,b,c], [a,b])) # Ok, no * for T
@@ -416,7 +416,7 @@ end
 
         @test p3 == P([1,2,1])
         @test pN * 10 == P([2760, 30, 870, 150, 240])
-        @test pN / 10.0 ==ᵟ P([27.6, 0.3, 8.7, 1.5, 2.4])
+        @test pN / 10.0 ≈ P([27.6, 0.3, 8.7, 1.5, 2.4])
         @test 10 * pNULL + pN ==ᵟ pN
         @test 10 * p0 + pN ==ᵟ pN
         @test p5 + 2 * p1 == P([3,4,6,4,1])
@@ -1350,7 +1350,7 @@ end
     @test degree(gcd(a*d, b*d, atol=sqrt(eps()))) > 0
     @test degree(gcd(a*d,b*d, method=:noda_sasaki)) == degree(d)
     @test_skip degree(gcd(a*d,b*d, method=:numerical)) == degree(d) # issues on some architectures (had test_skip)
-    l,m,n = (5,5,5) # sensitive to choice of `rtol` in ngcd
+    l,m,n = (4,4,4) #(5,5,5) # sensitive to choice of `rtol` in ngcd
     u,v,w = fromroots.(rand.((l,m,n)))
     @test degree(gcd(u*v, u*w, method=:numerical)) == degree(u)
 

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -228,7 +228,6 @@ end
             @test +p == p
             @test p + q == P([a+a,b+b,c])
             @test p - q == P([a-a,b-b,c])
-#            @test_throws MethodError p - p == P([0*a])  # no zeros to make zero polynomial
 
             # poly mult
             @test p * q == P(conv([a,b,c], [a,b]))
@@ -278,7 +277,6 @@ end
             @test +p == p
             @test p + q == P([a+a,b+b,c])
             @test p - q == P([a-a,b-b,c])
-##            @test_throws MethodError p - p == P([0*a])  # no zero(T) to make zero polynomial
 
             # poly mult
             @test_throws MethodError p * q == P(conv([a,b,c], [a,b])) # Ok, no * for T


### PR DESCRIPTION
more generic
* In #485 it was suggested to not guess output types of scalar multiplication. This moves more in that direction
* Uses `T[]` for the coefficients of a 0 polynomial, not `T[0]`, which requires `zero(T)`. This led to some fixes on evaluation and changed some tests
* new test in display of values which are 1 (`hasone(T)`) allows a few other polynomial constructions to be displayed

Speedups
* A comment in the `LaurentPolynomials.jl` package suggested performance problems with the `LaurentPolynomial` type. New approaches for `*` and `+` were added. Also, `gcdx` and `powermod` were borrowed from that package.
* The SparsePolynomial had a few arithmetic speedups, though it is still quite slow by comparison.
* fixed regression in scalar multiplication for the `ImmutablePolynomial` type
