### PR TITLE
Improve inference in derivative/integrate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "3.2.13"
+version = "3.2.14"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/polynomials/standard-basis.jl
+++ b/src/polynomials/standard-basis.jl
@@ -184,22 +184,22 @@ function derivative(p::P, order::Integer = 1) where {T, X, P <: StandardBasisPol
     order == 0 && return p
     d = degree(p)
     order > d  && return 0*p
-    hasnan(p) && return  ⟒(P)(zero(T)/zero(T), X) # NaN{T}
+    hasnan(p) && return  ⟒(P)(zero(T)/zero(T), Var(X)) # NaN{T}
 
     n = d + 1
     dp = [reduce(*, (i - order + 1):i, init = p[i]) for i ∈ order:d]
-    return ⟒(P)(dp, X)
+    return ⟒(P)(dp, Var(X))
 
 end
 
 function integrate(p::P) where {T, X, P <: StandardBasisPolynomial{T, X}}
 
-    hasnan(p) && return ⟒(P)(NaN, X)
+    hasnan(p) && return ⟒(P)(NaN, Var(X))
     iszero(p) && return zero(p)/1
 
     as = [pᵢ/(i+1) for (i, pᵢ) ∈ pairs(p)]
     pushfirst!(as, zero(constantterm(p)))
-    return ⟒(P)(as, X)
+    return ⟒(P)(as, Var(X))
 end
 
 

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -1032,9 +1032,17 @@ end
         c = [1, 2, 3, 4]
         p = P(c)
 
-        der = derivative(p)
+        der = if P == ImmutablePolynomial # poor inference
+            derivative(p)
+        else
+            @inferred derivative(p)
+        end
         @test coeffs(der) ==ᵗ⁰ [2, 6, 12]
-        int = integrate(der, 1)
+        int = if P == ImmutablePolynomial
+            integrate(der, 1)
+        else
+            @inferred integrate(der, 1)
+        end
         @test coeffs(int) ==ᵗ⁰ c
 
 


### PR DESCRIPTION
On master
```julia
julia> p = fromroots(Polynomial, Float64[1,1,2])
Polynomial(-2.0 + 5.0*x - 4.0*x^2 + 1.0*x^3)

julia> using Test

julia> @inferred derivative(p)
ERROR: return type Polynomial{Float64, :x} does not match inferred return type Polynomial{Float64}
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] top-level scope
   @ REPL[4]:1

julia> @inferred integrate(p)
ERROR: return type Polynomial{Float64, :x} does not match inferred return type Polynomial{Float64}
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] top-level scope
   @ REPL[5]:1
```
This PR fixes these. The inference test is skipped for `ImmutablePolynomial`, as the length doesn't appear to be inferred (and I see several open issues regarding this, so I haven't bothered looking into it).   