### PR TITLE
Type-stable ChebyshevT multiplication

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "4.0.3"
+version = "4.0.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/polynomials/chebyshev.jl
+++ b/src/polynomials/chebyshev.jl
@@ -174,7 +174,7 @@ function Base.:*(p1::MutableDensePolynomial{B,T,X}, p2::MutableDensePolynomial{B
     z2 = _c_to_z(coeffs(p2))
     prod = fastconv(z1, z2)
     cs = _z_to_c(prod)
-    ret = ChebyshevT(cs,X)
+    ret = ChebyshevT(cs, Var(X))
     return ret
 end
 

--- a/test/ChebyshevT.jl
+++ b/test/ChebyshevT.jl
@@ -124,7 +124,7 @@ end
     target[abs(i - j) + 1] += 0.5
     c1 = ChebyshevT(vcat(zeros(i), 1))
     c2 = ChebyshevT(vcat(zeros(j), 1))
-    @test c1 * c2 ≈ ChebyshevT(target)
+    @test @inferred(c1 * c2) ≈ ChebyshevT(target)
 
     # divrem
     target = c1 + c2


### PR DESCRIPTION
This PR makes `(::ChebyshevT) * (::ChebyshevT)` type-inferred