### PR TITLE
Throw DomainError for out-of-domain evaluation

### DIFF
--- a/src/polynomials/chebyshev.jl
+++ b/src/polynomials/chebyshev.jl
@@ -135,7 +135,8 @@ julia> c.(-1:0.5:1)
 ```
 """
 function evalpoly(x::S, ch::ChebyshevT) where {S}
-    x ∉ domain(ch) && throw(ArgumentError("$x outside of domain"))
+    d = domain(ch)
+    x ∉ d && throw(DomainError(x, "evaluation point must lie in $d"))
     evalpoly(x, ch, false)
 end
 

--- a/test/ChebyshevT.jl
+++ b/test/ChebyshevT.jl
@@ -16,6 +16,8 @@
         @test size(p, 1) == size(coeff, 1)
         @test typeof(p).parameters[2] == eltype(coeff)
         @test eltype(p) == eltype(coeff)
+
+        @test_throws DomainError p(2)
     end
 end
 


### PR DESCRIPTION
This PR changes `ArgumentError` to `DomainError` when `ChebyshevT` is evaluated outside the domain.
```julia
julia> x = ChebyshevT([0,1]);

julia> x(2)
ERROR: DomainError with 2:
evaluation point must lie in [-1..1]
[...]
```