### PR TITLE
Test using Aqua v0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ PolynomialsMakieCoreExt = "MakieCore"
 PolynomialsMutableArithmeticsExt = "MutableArithmetics"
 
 [compat]
-Aqua = "0.6, 0.7"
+Aqua = "0.8"
 ChainRulesCore = "1"
 ChainRulesTestUtils = "1"
 DualNumbers = "0.6"

--- a/src/polynomial-container-types/immutable-dense-polynomial.jl
+++ b/src/polynomial-container-types/immutable-dense-polynomial.jl
@@ -24,7 +24,8 @@ ImmutableDensePolynomial{B,T,X,N}(check::Type{Val{true}}, cs::NTuple{N,T}) where
     ImmutableDensePolynomial{B,T,X,N}(cs)
 
 # tuple with mismatched size
-function ImmutableDensePolynomial{B,T,X,N}(xs::NTuple{M,S}) where {B,T,S,X,N,M}
+function ImmutableDensePolynomial{B,T,X,N}(xs::Tuple{S,Vararg{S}}) where {B,T,S,X,N}
+    M = length(xs)
     p = ImmutableDensePolynomial{B,S,X,M}(xs)
     convert(ImmutableDensePolynomial{B,T,X,N}, ImmutableDensePolynomial{B,T,X,M}(xs))
 end
@@ -46,10 +47,13 @@ function ImmutableDensePolynomial{B,T,X,N}(c::S) where {B,T,X,N,S<:Scalar}
     cs = ntuple(i -> i == 1 ? T(c) : zero(T), Val(N))
     return ImmutableDensePolynomial{B,T,X,N}(cs)
 end
-ImmutableDensePolynomial{B,T,X}(::Val{false}, xs::NTuple{N,S}) where {B,T,S,X,N} = ImmutableDensePolynomial{B,T,X,N}(convert(NTuple{N,T}, xs))
+function ImmutableDensePolynomial{B,T,X}(::Val{false}, xs::Tuple{S,Vararg{S}}) where {B,T,S,X}
+    N = length(xs)
+    ImmutableDensePolynomial{B,T,X,N}(convert(NTuple{N,T}, xs))
+end
 ImmutableDensePolynomial{B,T,X}(xs::NTuple{N}) where {B,T,X,N} = ImmutableDensePolynomial{B,T,X,N}(convert(NTuple{N,T}, xs))
 ImmutableDensePolynomial{B,T}(xs::NTuple{N}, var::SymbolLike=Var(:x)) where {B,T,N} = ImmutableDensePolynomial{B,T,Symbol(var),N}(xs)
-ImmutableDensePolynomial{B}(xs::NTuple{N,T}, var::SymbolLike=Var(:x)) where {B,T,N} = ImmutableDensePolynomial{B,T,Symbol(var),N}(xs)
+ImmutableDensePolynomial{B}(xs::Tuple{T,Vararg{T}}, var::SymbolLike=Var(:x)) where {B,T} = ImmutableDensePolynomial{B,T,Symbol(var),length(xs)}(xs)
 
 # abstract vector. Must eat order
 ImmutableDensePolynomial{B,T,X}(::Val{false}, xs::AbstractVector, order::Int=0) where {B,T,X} =

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -1,6 +1,3 @@
 using Aqua
 
-Aqua.test_all(Polynomials;
-              unbound_args = false,
-              stale_deps   = false
-              )
+Aqua.test_all(Polynomials)


### PR DESCRIPTION
Also, rewrite method signatures to get all the Aqua tests to pass. The idea there is that in the `NTuple{N,T}`  form, `T` isn't known if `N==0`. Rewriting this as `Tuple{T, Vararg{T}}` ensures that `T` is not ambiguous.