### PR TITLE
Add versioned Manifest files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ docs/site/
 *.jl.mem
 
 Manifest.toml
+Manifest-v*.*.toml
 archive/
 .benchmarkci


### PR DESCRIPTION
Julia v1.11 adds support for versioned Manifest files, and we may ignore these as well in the git repo.