### PR TITLE
close #590; use deepcopy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "4.0.13"
+version = "4.0.14"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/polynomials/ngcd.jl
+++ b/src/polynomials/ngcd.jl
@@ -540,7 +540,7 @@ function refine_uvw!(u::P, v::P, w::P,
     Δz = ones(T, length(u) + length(v) + length(w))
     n = size(A, 2)
     R = UpperTriangular(Matrix{T}(undef, n, n))
-    R′ = copy(R)
+    R′ = deepcopy(R)
     ũ, ṽ, w̃ = copy(u), copy(v), copy(w)
 
     steps = 0

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -1019,6 +1019,14 @@ end
         @test isempty(out.values)
         @test isempty(out.multiplicities)
     end
+
+    ## past issues
+
+    ## issue #590
+    pb = BigInt[-1, 2, -1]
+    out = Polynomials.Multroot.multroot(Polynomials.Polynomial(pb))
+    @test out.values ≈ [1.0] && out.multiplicities == [2]
+
 end
 
 @testset "critical points" begin


### PR DESCRIPTION
Uses `deepcopy` not `copy` (which had issues with `BigInt` type).