### PR TITLE
fix issue #593

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "4.0.15"
+version = "4.0.16"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/StandardBasis.jl
+++ b/test/StandardBasis.jl
@@ -1038,9 +1038,14 @@ end
     q = Polynomial(dencoeffs)
     r = p//q
 
-    @test_throws ArgumentError poles(r)
-    out = poles(r; multroot_method=:iterative)
+    out = roots(r)
     @test out.multiplicities == [3]
+    our = poles(r)
+    @test out.multiplicities == [3]
+
+    multroot_method = :direct # fails if direct
+    @test_throws ArgumentError poles(r; multroot_method)
+    @test_throws ArgumentError roots(r; multroot_method)
 end
 
 @testset "critical points" begin


### PR DESCRIPTION
Make a default `multroot_method` to call `:iterative` when big numbers are passed and `:direct` otherwise. (Hopefully this fixes issue #593, but it may be that the underlying algorithms are Float64 dependent, especially the tolerances which are chosen following the Zheng paper.)