### PR TITLE
check for exact coefficients; close #600

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "4.0.18"
+version = "4.0.19"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,3 +1,4 @@
 [default.extend-words]
 Pn = "Pn"
 zerod = "zerod"
+Comput = "Comput"

--- a/src/polynomials/standard-basis/standard-basis.jl
+++ b/src/polynomials/standard-basis/standard-basis.jl
@@ -197,7 +197,7 @@ function Base.divrem(num::P, den::Q) where {B<:StandardBasis,
 
     m == -1 && throw(DivideError())
     if m == 0
-        if hasmethod(eps, S) # some way to check if using ≈ or == is appropriate
+        if hasmethod(eps, (S,)) # some way to check if using ≈ or == is appropriate
             den[0] ≈ 0 && throw(DivideError())
         else
             den[0] == 0 && throw(DivideError())

--- a/src/polynomials/standard-basis/standard-basis.jl
+++ b/src/polynomials/standard-basis/standard-basis.jl
@@ -196,7 +196,14 @@ function Base.divrem(num::P, den::Q) where {B<:StandardBasis,
     m = degree(den)
 
     m == -1 && throw(DivideError())
-    if m == 0 && den[0] ≈ 0 throw(DivideError()) end
+    if m == 0
+        if hasmethod(eps, S) # some way to check if useing ≈ or == is appropriate
+            den[0] ≈ 0 && throw(DivideError())
+        else
+            den[0] == 0 && throw(DivideError())
+        end
+    end
+
 
     R = eltype(one(T)/one(S))
 

--- a/src/polynomials/standard-basis/standard-basis.jl
+++ b/src/polynomials/standard-basis/standard-basis.jl
@@ -197,7 +197,7 @@ function Base.divrem(num::P, den::Q) where {B<:StandardBasis,
 
     m == -1 && throw(DivideError())
     if m == 0
-        if hasmethod(eps, S) # some way to check if useing ≈ or == is appropriate
+        if hasmethod(eps, S) # some way to check if using ≈ or == is appropriate
             den[0] ≈ 0 && throw(DivideError())
         else
             den[0] == 0 && throw(DivideError())


### PR DESCRIPTION
Closes #600 by avoiding a call to `isapprox` when coefficients are exact.

(This might be needed elsewhere; in which case abstracting the test `hasmethod(eps, T)` would be useful.)