### PR TITLE
adjust to dropping MakieCore

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -6,20 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       lookback:
-        default: 3
-permissions:
-  actions: read
-  checks: read
-  contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
+        default: "3"
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6' # lowest supported version
+          - '1.10' # lowest supported version
           - '1'   # last released version
         os:
           - ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       # needed to allow julia-actions/cache to proactively delete old caches that it has created
-      actions: write 
+      actions: write
       contents: write
     steps:
       - uses: actions/checkout@v4

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
 author = "JuliaMath"
-version = "4.0.21"
+version = "4.1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -41,7 +41,7 @@ Setfield = "1"
 SparseArrays = "<0.0.1, 1"
 SpecialFunctions = "1,2"
 Test = "<0.0.1, 1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
This is brought about by #607. 

It basically adjusts to a change of MakieCore to Makie due to downstream changes. This required dropping support pre v1.10. The branch 4.0.21  is available for earlier Julia versions.