### PR TITLE
New method for derivative of constant ImmutableDensePolynomial

### DIFF
--- a/src/polynomials/standard-basis/immutable-polynomial.jl
+++ b/src/polynomials/standard-basis/immutable-polynomial.jl
@@ -142,11 +142,11 @@ end
 
 # special cases are much more performant
 derivative(p::ImmutableDensePolynomial{B,T,X,0}) where {B<:StandardBasis,T,X} = p
-function derivative(p::ImmutableDensePolynomial{B,T,X,1}) where {B<:StandardBasis,T,X}
-    ImmutableDensePolynomial{B,T,X,1}(zero(T))
-end
+derivative(p::ImmutableDensePolynomial{B,T,X,1}) where {B<:StandardBasis,T,X} = zero(p)
+
 function derivative(p::ImmutableDensePolynomial{B,T,X,N}) where {B<:StandardBasis,T,X,N}
     N == 0 && return p
+    N == 1 && return zero(p)
     hasnan(p) && return ImmutableDensePolynomial{B,T,X,1}(zero(T)/zero(T)) # NaN{T}
     cs = ntuple(i -> i*p.coeffs[i+1], Val(N-1))
     R = eltype(cs)

--- a/src/polynomials/standard-basis/immutable-polynomial.jl
+++ b/src/polynomials/standard-basis/immutable-polynomial.jl
@@ -142,6 +142,9 @@ end
 
 # special cases are much more performant
 derivative(p::ImmutableDensePolynomial{B,T,X,0}) where {B<:StandardBasis,T,X} = p
+function derivative(p::ImmutableDensePolynomial{B,T,X,1}) where {B<:StandardBasis,T,X}
+    ImmutableDensePolynomial{B,T,X,1}(zero(T))
+end
 function derivative(p::ImmutableDensePolynomial{B,T,X,N}) where {B<:StandardBasis,T,X,N}
     N == 0 && return p
     hasnan(p) && return ImmutableDensePolynomial{B,T,X,1}(zero(T)/zero(T)) # NaN{T}


### PR DESCRIPTION
Currently `derivative` does not work properly on a _constant_ `ImmutablePolynomial`. 
In the example
```
p = ImmutablePolynomial(1.) # defines a constant polynomial
dp = derivative(p)
```
the returned `dp` is of type `ImmutablePolynomial{Union{},:x,0}`, which is unusable (cannot be shown nor evaluated). 

This pull request fixes this issue by introducing a new method: 

```
function derivative(p::ImmutableDensePolynomial{B,T,X,1}) where {B<:StandardBasis,T,X}
    ImmutableDensePolynomial{B,T,X,1}(zero(T))
end
```
This returns the zero `ImmutablePolynomial`, that works fine in all my tests: it evaluates to zero(T) for every input, it produces the zero `ImmutablePolynomial` (or `Polynomial`) when multiplied by any other polynomial and it integrates to itself. 

I think that there maybe some other issue in the other variants of `derivative`. In particular, I fail to see the meaning of `ImmutablePolynomial{T,X,N}` when `N=0`, which is treated in a special `derivative` method but is also considered in the main  one. As far as I understand the code, all references to the case `N=0` should be removed, and the `zero` polynomial should be interpreted as having `N=1`, since it has one coefficient. I have not make any changes in this direction, however, just in case I am missing something. 