### PR TITLE
Thinzero; close issue #623

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,8 @@
 name = "Polynomials"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 license = "MIT"
-author = "JuliaMath"
 version = "4.1.1"
+author = "JuliaMath"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/common.jl
+++ b/src/common.jl
@@ -611,7 +611,7 @@ Is this a ``0`` polynomial.
 For most types, the ``0`` polynomial is one with no coefficients (coefficient vector `T[]`),
 though some types have the possibility of trailing zeros. The degree of a zero polynomial is conventionally ``-1``, though this is not the convention for Laurent polynomials.
 """
-Base.iszero(p::AbstractPolynomial) = all(_iscoeffzero, values(p))::Bool
+Base.iszero(p::AbstractPolynomial) = all(iscoeffzero, values(p))::Bool
 
 
 # See discussions in https://github.com/JuliaMath/Polynomials.jl/issues/258

--- a/src/contrib.jl
+++ b/src/contrib.jl
@@ -147,9 +147,9 @@ end
 constructorof(::Type{T}) where T = Base.typename(T).wrapper
 
 ## Issue #623 with Interval package
-## Can override this method
-_iscoeffzero(x::Number) = iszero(x)
-
+## Can override these methods, say with IntervalArithmetic
+iscoeffzero(x) = iszero(x)
+iscoeffone(x)  = isone(x)
 
 # Define our own minimal Interval type, inspired by Intervals.jl.
 # We vendor it in to avoid adding the heavy Intervals.jl dependency and
@@ -209,7 +209,7 @@ end
 
 Base.isopen(I::Interval{T,L,R}) where {T,L,R} = (L != Closed && R != Closed)
 
-function _iscoeffzero(I::Interval)
+function iscoeffzero(I::Interval)
     l,r = extrema(I)
     iszero(l) && iszero(r)
 end

--- a/src/polynomial-container-types/immutable-dense-polynomial.jl
+++ b/src/polynomial-container-types/immutable-dense-polynomial.jl
@@ -20,7 +20,7 @@ struct ImmutableDensePolynomial{B,T,X,N} <: AbstractDenseUnivariatePolynomial{B,
     # need zero(T) defined if padding needed
     function ImmutableDensePolynomial{B,T,X,N}(xs::Tuple{Vararg}) where {B,T,X,N}
         M = length(xs)
-        N′ = findlast(!iszero, xs)
+        N′ = findlast(!iscoeffzero, xs)
         N < N′ && throw(ArgumentError("Too many coefficients for type"))
         if  N == N′ == M
             cs = T.(xs)
@@ -150,8 +150,8 @@ Base.similar(p::ImmutableDensePolynomial, args...) = p.coeffs
 # not type stable, as N is value dependent
 function trim_trailing_zeros!!(cs::Tuple)
     isempty(cs) && return cs
-    !iszero(last(cs)) && return cs
-    i = findlast(!iszero, cs)
+    !iscoeffzero(last(cs)) && return cs
+    i = findlast(!iscoeffzero, cs)
     i == nothing && return ()
     xs = ntuple(Base.Fix1(getindex,cs), i)
     xs
@@ -261,7 +261,7 @@ end
 ## ---
 degree(p::ImmutableDensePolynomial{B,T,X,0}) where {B,T,X} = -1
 function degree(p::ImmutableDensePolynomial{B,T,X,N}) where {B,T,X,N}
-    i = findlast(!iszero, p.coeffs)
+    i = findlast(!iscoeffzero, p.coeffs)
     isnothing(i) && return -1
     return i - 1
 end

--- a/src/polynomial-container-types/mutable-dense-laurent-polynomial.jl
+++ b/src/polynomial-container-types/mutable-dense-laurent-polynomial.jl
@@ -20,11 +20,11 @@ struct MutableDenseLaurentPolynomial{B,T,X} <: AbstractLaurentUnivariatePolynomi
             cs, order = cs.parent, firstindex(cs)
         end
 
-        i = findlast(!iszero, cs)
+        i = findlast(!iscoeffzero, cs)
         if i === nothing
             xs = T[]
         else
-            j = findfirst(!iszero, cs)
+            j = findfirst(!iscoeffzero, cs)
             xs = T[cs[i] for i ∈ j:i]
             order = order + j - 1
         end
@@ -101,10 +101,10 @@ _zeros(::Type{<:MutableDenseLaurentPolynomial}, z, N)  = fill(z, N)
 Base.similar(p::MutableDenseLaurentPolynomial, args...) = similar(p.coeffs, args...)
 
 # iszero
-Base.iszero(p::MutableDenseLaurentPolynomial) = iszero(p.coeffs)::Bool
+Base.iszero(p::MutableDenseLaurentPolynomial) = all(iscoeffzero, p.coeffs)::Bool
 
 function degree(p::MutableDenseLaurentPolynomial)
-    i = findlast(!iszero, p.coeffs)
+    i = findlast(!iscoeffzero, p.coeffs)
     isnothing(i) && return -1
     firstindex(p) + i - 1
 end
@@ -226,7 +226,7 @@ end
 
 ## ---
 function LinearAlgebra.lmul!(c::Scalar, p::MutableDenseLaurentPolynomial{B,T,X}) where {B,T,X}
-    if iszero(c)
+    if iscoeffzero(c)
         empty!(p.coeffs)
         p.order[] = 0
     else
@@ -236,7 +236,7 @@ function LinearAlgebra.lmul!(c::Scalar, p::MutableDenseLaurentPolynomial{B,T,X})
 end
 
 function LinearAlgebra.rmul!(p::MutableDenseLaurentPolynomial{B,T,X}, c::Scalar) where {B,T,X}
-    if iszero(c)
+    if iscoeffzero(c)
         empty!(p.coeffs)
         p.order[] = 0
     else

--- a/src/polynomial-container-types/mutable-dense-polynomial.jl
+++ b/src/polynomial-container-types/mutable-dense-polynomial.jl
@@ -9,7 +9,7 @@ struct MutableDensePolynomial{B,T,X} <: AbstractDenseUnivariatePolynomial{B,T,X}
             @warn "ignoring the axis offset of the coefficient vector"
             cs = parent(cs)
         end
-        i = findlast(!iszero, cs)
+        i = findlast(!iscoeffzero, cs)
         if i == nothing
             xs = T[]
         else
@@ -87,7 +87,7 @@ Base.pairs(p::MutableDensePolynomial) =
 
 function coeffs(p::MutableDensePolynomial)
     firstindex(p) < 0 && throw(ArgumentError("Polynomial has negative index terms. Use `pairs` instead`"))
-    iszero(firstindex(p)) && return p.coeffs
+    iscoeffzero(firstindex(p)) && return p.coeffs
     return [p[i] for i ∈ 0:lastindex(p)]
 end
 
@@ -98,7 +98,7 @@ _zeros(::Type{<:MutableDensePolynomial}, z, N)  = fill(z, N)
 Base.similar(p::MutableDensePolynomial, args...) = similar(p.coeffs, args...)
 
 # iszero
-Base.iszero(p::MutableDensePolynomial)::Bool = all(_iscoeffzero, p.coeffs)
+Base.iszero(p::MutableDensePolynomial)::Bool = all(iscoeffzero, p.coeffs)
 
 function degree(p::MutableDensePolynomial)
     length(p.coeffs) - 1
@@ -108,8 +108,8 @@ basis(::Type{MutableDensePolynomial{B,T,X}},i::Int) where {B,T,X} = MutableDense
 
 function trim_trailing_zeros!!(cs::Vector{T}) where {T}
     isempty(cs) && return cs
-    !iszero(last(cs)) && return cs
-    i = findlast(!iszero, cs)
+    !iscoeffzero(last(cs)) && return cs
+    i = findlast(!iscoeffzero, cs)
     if isnothing(i)
         empty!(cs)
     else

--- a/src/polynomials/factored_polynomial.jl
+++ b/src/polynomials/factored_polynomial.jl
@@ -223,7 +223,7 @@ end
 ## ----
 domain(::Type{<:FactoredPolynomial}) = Interval{Open,Open}(-Inf, Inf)
 mapdomain(::Type{<:FactoredPolynomial}, x::AbstractArray) = x
-Base.iszero(p::FactoredPolynomial) = _iscoeffzero(p.c)
+Base.iszero(p::FactoredPolynomial) = iscoeffzero(p.c)
 
 Base.zero(::Type{FactoredPolynomial{T,X}}) where {T, X} = FactoredPolynomial{T,X}(Dict{T,Int}(),     zero(T))
 Base.one(::Type{FactoredPolynomial{T,X}}) where {T, X}  = FactoredPolynomial{T,X}(Dict{T,Int}(),     one(T))

--- a/src/show.jl
+++ b/src/show.jl
@@ -6,11 +6,11 @@ export printpoly
 ## to handle this case we create some functions
 ## which can be modified by users for other Ts
 
-_iszero(x::T) where {T} = (x == zero(T)) === true
-_iszero(x::AbstractArray{T}) where {T} = all(isequal.(x, zero(T)))
+_iszero(x::T) where {T} = iscoeffzero(x) #(x == zero(T)) === true
+_iszero(x::AbstractArray{T}) where {T} = all(iscoeffzero, x)
 
-_isone(x::T) where {T} = (x == one(T)) === true
-_isone(x::AbstractArray{T}) where {T} = all(isequal.(x, one(T)))
+_isone(x::T) where {T} = iscoeffone(x) #(x == one(T)) === true
+_isone(x::AbstractArray{T}) where {T} = all(iscoeffone, x)
 
 "`hasneg(::T)` attribute is true if: `pj < zero(T)` is defined."
 hasneg(::Type{T}) where {T} = false


### PR DESCRIPTION
This addresses issue #623 by incorporating two new functions that can be overridden: `iscoeffzero` and `iscoeffone` which default to `iszero` and `isone`. With this, we have:

```
julia> using Polynomials

julia> using IntervalArithmetic

julia> a = interval(-1,1); z = interval(0,0)
[0.0, 0.0]_com

julia> p = Polynomial([a,z,a])
ERROR: ArgumentError: `==` is purposely not supported for overlapping non-thin intervals. See instead `isequal_interval`

julia> Polynomials.iscoeffzero(x::Interval) = isthinzero(x)

julia> Polynomials.iscoeffone(x::Interval) = isthinone(x)

julia> p = Polynomial([a,z,a])
Polynomial([-1.0, 1.0]_com + [-1.0, 1.0]_com*x^2)

julia> p*p
Polynomial([-1.0, 1.0]_com + [-2.0, 2.0]_com*x^2 + [-1.0, 1.0]_com*x^4)
```


